### PR TITLE
feat: allow create contraption using net interface

### DIFF
--- a/src/main/java/com/wintercogs/beyonddimensions/client/gui/NetInterfaceBaseGUI.java
+++ b/src/main/java/com/wintercogs/beyonddimensions/client/gui/NetInterfaceBaseGUI.java
@@ -47,8 +47,12 @@ public class NetInterfaceBaseGUI extends BDBaseGUI<NetInterfaceBaseMenu>
         popButton = new RightTabButton(this.leftPos + 176, this.topPos + 6, 23, 26,
                 this.leftPos + 176 + 3, this.topPos + 6 + 4, 16, 16, button ->
         {
+            if (!menu.getAccess().canConfigurePopMode())
+            {
+                return;
+            }
             popButton.toggleState();
-            menu.be.popMode = (PopMode) popButton.currentState;
+            menu.getAccess().setPopMode((PopMode) popButton.currentState);
             menu.writeAndSendQuickData();
         })
         {
@@ -64,15 +68,20 @@ public class NetInterfaceBaseGUI extends BDBaseGUI<NetInterfaceBaseMenu>
 
                 this.states.addAll(iconMap.keySet());
 
-                setState(menu.be.popMode);
+                setState(menu.getAccess().getPopMode());
             }
         };
+        if (!menu.getAccess().canConfigurePopMode())
+        {
+            popButton.active = false;
+            popButton.setTooltip(Tooltip.create(Component.translatable("tooltip.button.beyonddimensions.popmode_mounted_unavailable")));
+        }
         addRenderableWidget(popButton);
 
         controlModeButton = new RightTabButton(leftPos + 176, topPos + 36, 23, 26,
                 leftPos + 176 + 3, topPos + 36 + 4, 16, 16, button -> {
             controlModeButton.toggleState();
-            menu.be.controlMode = (RedStoneControlMode) controlModeButton.currentState;
+            menu.getAccess().setControlMode((RedStoneControlMode) controlModeButton.currentState);
             menu.writeAndSendQuickData();
         })
         {
@@ -91,7 +100,7 @@ public class NetInterfaceBaseGUI extends BDBaseGUI<NetInterfaceBaseMenu>
 
                 this.states.addAll(iconMap.keySet());
 
-                setState(menu.be.controlMode);
+                setState(menu.getAccess().getControlMode());
             }
         };
         addRenderableWidget(controlModeButton);
@@ -99,7 +108,7 @@ public class NetInterfaceBaseGUI extends BDBaseGUI<NetInterfaceBaseMenu>
         fuzzyModelButton = new RightTabButton(leftPos + 176, topPos + 66, 23, 26,
                 leftPos + 176 + 3, topPos + 66 + 4, 16, 16, button -> {
             fuzzyModelButton.toggleState();
-            menu.be.fuzzyMode = (FuzzyMode) fuzzyModelButton.currentState;
+            menu.getAccess().setFuzzyMode((FuzzyMode) fuzzyModelButton.currentState);
             menu.writeAndSendQuickData();
         })
         {
@@ -114,7 +123,7 @@ public class NetInterfaceBaseGUI extends BDBaseGUI<NetInterfaceBaseMenu>
 
                 this.states.addAll(iconMap.keySet());
 
-                setState(menu.be.fuzzyMode);
+                setState(menu.getAccess().getFuzzyMode());
             }
         };
         addRenderableWidget(fuzzyModelButton);
@@ -138,12 +147,12 @@ public class NetInterfaceBaseGUI extends BDBaseGUI<NetInterfaceBaseMenu>
         //父类无操作
         //每tick自动更新搜索方案
 
-        if (popButton.currentState != menu.be.popMode)
-            popButton.setState(menu.be.popMode);
-        if (controlModeButton.currentState != menu.be.controlMode)
-            controlModeButton.setState(menu.be.controlMode);
-        if (fuzzyModelButton.currentState != menu.be.fuzzyMode)
-            fuzzyModelButton.setState(menu.be.fuzzyMode);
+        if (popButton.currentState != menu.getAccess().getPopMode())
+            popButton.setState(menu.getAccess().getPopMode());
+        if (controlModeButton.currentState != menu.getAccess().getControlMode())
+            controlModeButton.setState(menu.getAccess().getControlMode());
+        if (fuzzyModelButton.currentState != menu.getAccess().getFuzzyMode())
+            fuzzyModelButton.setState(menu.getAccess().getFuzzyMode());
     }
 
     @Override

--- a/src/main/java/com/wintercogs/beyonddimensions/common/block/NetInterfaceBlock.java
+++ b/src/main/java/com/wintercogs/beyonddimensions/common/block/NetInterfaceBlock.java
@@ -29,7 +29,10 @@ public class NetInterfaceBlock extends BaseMachineBlock
         super.useWithoutItem(state, level, pos, player, hitResult);
         if (!level.isClientSide() && !player.isShiftKeyDown())
         {
-            player.openMenu((NetInterfaceBlockEntity) level.getBlockEntity(pos), pos);
+            player.openMenu((NetInterfaceBlockEntity) level.getBlockEntity(pos), buf -> {
+                buf.writeBoolean(false);
+                buf.writeBlockPos(pos);
+            });
         }
         return InteractionResult.SUCCESS_NO_ITEM_USED;
     }

--- a/src/main/java/com/wintercogs/beyonddimensions/common/block/entity/NetInterfaceBlockEntity.java
+++ b/src/main/java/com/wintercogs/beyonddimensions/common/block/entity/NetInterfaceBlockEntity.java
@@ -18,7 +18,10 @@ import com.wintercogs.beyonddimensions.common.init.BDItems;
 import com.wintercogs.beyonddimensions.common.item.MatterCompressionBall;
 import com.wintercogs.beyonddimensions.common.machine.FuzzyMode;
 import com.wintercogs.beyonddimensions.common.machine.PopMode;
+import com.wintercogs.beyonddimensions.common.machine.RedStoneControlMode;
+import com.wintercogs.beyonddimensions.common.menu.NetInterfaceAccess;
 import com.wintercogs.beyonddimensions.common.menu.NetInterfaceBaseMenu;
+import com.wintercogs.beyonddimensions.common.menu.NetInterfaceSettings;
 import com.wintercogs.beyonddimensions.config.CommonConfigRuntime;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -43,7 +46,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 
-public class NetInterfaceBlockEntity extends BaseMachineBlockEntity implements MenuProvider
+public class NetInterfaceBlockEntity extends BaseMachineBlockEntity implements MenuProvider, NetInterfaceAccess
 {
 
     private static final int capacity = CommonConfigRuntime.interfaceUsableCapacity;
@@ -70,9 +73,7 @@ public class NetInterfaceBlockEntity extends BaseMachineBlockEntity implements M
         }
     };
 
-    public PopMode popMode = PopMode.STOP;
-
-    public FuzzyMode fuzzyMode = FuzzyMode.DISABLE;
+    private final NetInterfaceSettings settings = new NetInterfaceSettings();
 
     private final Direction[] directions = Direction.values();
 
@@ -91,6 +92,34 @@ public class NetInterfaceBlockEntity extends BaseMachineBlockEntity implements M
     public StackHandler getFakeStackHandler()
     {
         return this.fakeStackHandler;
+    }
+
+    @Override
+    public NetInterfaceSettings getNetInterfaceSettings()
+    {
+        return this.settings;
+    }
+
+    @Override
+    public void setControlMode(RedStoneControlMode controlMode)
+    {
+        this.controlMode = controlMode;
+    }
+
+    @Override
+    public boolean isMenuValid()
+    {
+        return !this.isRemoved();
+    }
+
+    @Override
+    public void onMenuDataChanged()
+    {
+        if (this.level != null && !this.level.isClientSide())
+        {
+            this.level.blockEntityChanged(this.getBlockPos());
+            this.level.sendBlockUpdated(this.getBlockPos(), this.getBlockState(), this.getBlockState(), 2);
+        }
     }
 
     public int getRedstoneLevel()
@@ -138,7 +167,7 @@ public class NetInterfaceBlockEntity extends BaseMachineBlockEntity implements M
         if (CommonConfigRuntime.interfaceCanPopResource)
         {
             // 尝试输出物品到周围
-            if (popMode == PopMode.OPEN)
+            if (getPopMode() == PopMode.OPEN)
             {
                 // 在使用缓存前确保它是最新的
                 updateCapabilityCache();
@@ -217,78 +246,12 @@ public class NetInterfaceBlockEntity extends BaseMachineBlockEntity implements M
 
     public void transferToNet()
     {
-        // 只有不被标记的槽位才会被收纳进入网络
-        DimensionsNet net = getNet();
-        if (net != null)
-        {
-            for (int i = 0; i < capacity; i++)
-            {
-                KeyAmount flag = fakeStackHandler.getStackBySlot(i);
-                if (!flag.isEmpty())
-                {
-                    if (flag.key().isSameTypeSameComponents(stackHandler.getStackBySlot(i).key()))
-                        continue;
-                }
-                KeyAmount stack = stackHandler.getStackBySlot(i);
-                if (!stack.isEmpty())
-                {
-                    KeyAmount extracted = stackHandler.extract(i, stack.amount(), false);
-                    KeyAmount remaining = net.getUnifiedStorage().insert(extracted.key(), extracted.amount(), false);
-                    if (!remaining.isEmpty())
-                        stackHandler.insert(i, remaining.key(), remaining.amount(), false);
-                }
-            }
-        }
+        NetInterfaceAccess.transferToNet(getNet(), stackHandler, fakeStackHandler, capacity);
     }
 
-    // 从网络中获取物品，然后转移到槽位
     public void transferFromNet()
     {
-        // 首先检测标记
-        // 然后从网络提取适当标记物
-        // 插入物品槽
-        // 将剩余插回网络
-        DimensionsNet net = getNet();
-        if (net != null)
-        {
-            for (int i = 0; i < capacity; i++)
-            {
-                KeyAmount flag = fakeStackHandler.getStackBySlot(i);
-                if (!flag.isEmpty())
-                {
-                    // 到达数量上限或者是不同物品则不尝试插入
-                    KeyAmount current = stackHandler.getStackBySlot(i);
-                    if (!current.isEmpty())
-                    {
-                        if (current.key().getVanillaMaxStackSize() >= current.amount())
-                        {
-                            continue;
-                        }
-                        if (!current.key().isSameTypeSameComponents(flag.key()))
-                        {
-                            continue;
-                        }
-                    }
-
-                    // 插入逻辑
-                    KeyAmount stack = net.getUnifiedStorage().extract(
-                            flag.key(),
-                            flag.key().getVanillaMaxStackSize(),
-                            false,
-                            fuzzyMode == FuzzyMode.ENABLE
-                    );
-                    if (!stack.isEmpty())
-                    {
-                        KeyAmount remaining = stackHandler.insert(i, stack.key(), stack.amount(), false);
-                        if (!remaining.isEmpty())
-                        {
-                            net.getUnifiedStorage().insert(remaining.key(), remaining.amount(), false);
-                        }
-                    }
-                }
-
-            }
-        }
+        NetInterfaceAccess.transferFromNet(getNet(), stackHandler, fakeStackHandler, capacity, getFuzzyMode());
     }
 
     public void popStack()
@@ -304,12 +267,12 @@ public class NetInterfaceBlockEntity extends BaseMachineBlockEntity implements M
                     {
                         if (fakeStackHandler.getStackBySlot(i).key().getTypeId().equals(typeId))
                         {
-                            if (this.fuzzyMode == FuzzyMode.ENABLE
+                            if (getFuzzyMode() == FuzzyMode.ENABLE
                                     && !fakeStackHandler.getStackBySlot(i).key().isSame(stackHandler.getStackBySlot(i).key()))
                             {
                                 continue;
                             }
-                            if (this.fuzzyMode == FuzzyMode.DISABLE
+                            if (getFuzzyMode() == FuzzyMode.DISABLE
                                     && !fakeStackHandler.getStackBySlot(i).key().isSameTypeSameComponents(stackHandler.getStackBySlot(i).key()))
                             {
                                 continue;
@@ -374,25 +337,25 @@ public class NetInterfaceBlockEntity extends BaseMachineBlockEntity implements M
         String popModeNew = tag.getString("pop_mode");
         if (!popModeNew.isEmpty())
         {
-            this.popMode = PopMode.valueOf(popModeNew);
+            setPopMode(PopMode.valueOf(popModeNew));
         }
         else if (!tag.getString("popMode").isEmpty())
         {
-            this.popMode = PopMode.valueOf(tag.getString("popMode"));
+            setPopMode(PopMode.valueOf(tag.getString("popMode")));
         }
         else if (tag.getBoolean("popMode"))
         {
-            this.popMode = PopMode.OPEN;
+            setPopMode(PopMode.OPEN);
         }
         else
         {
-            this.popMode = PopMode.STOP;
+            setPopMode(PopMode.STOP);
         }
 
         String fuzzyModeNew = tag.getString("fuzzy_mode");
         if (!fuzzyModeNew.isEmpty())
         {
-            this.fuzzyMode = FuzzyMode.valueOf(fuzzyModeNew);
+            setFuzzyMode(FuzzyMode.valueOf(fuzzyModeNew));
         }
         // 加载后需要更新缓存
         setNeedsCapabilityUpdate();
@@ -404,8 +367,8 @@ public class NetInterfaceBlockEntity extends BaseMachineBlockEntity implements M
         super.saveAdditional(tag, registries);
         tag.put("inventory", stackHandler.serializeNBT(registries));
         tag.put("flags", fakeStackHandler.serializeNBT(registries));
-        tag.putString("pop_mode", this.popMode.name());
-        tag.putString("fuzzy_mode", this.fuzzyMode.name());
+        tag.putString("pop_mode", getPopMode().name());
+        tag.putString("fuzzy_mode", getFuzzyMode().name());
     }
 
     @Override

--- a/src/main/java/com/wintercogs/beyonddimensions/common/menu/NetInterfaceAccess.java
+++ b/src/main/java/com/wintercogs/beyonddimensions/common/menu/NetInterfaceAccess.java
@@ -1,0 +1,98 @@
+package com.wintercogs.beyonddimensions.common.menu;
+
+import com.wintercogs.beyonddimensions.api.dimensionnet.DimensionsNet;
+import com.wintercogs.beyonddimensions.api.storage.handler.impl.StackHandler;
+import com.wintercogs.beyonddimensions.api.storage.key.KeyAmount;
+import com.wintercogs.beyonddimensions.common.machine.FuzzyMode;
+import com.wintercogs.beyonddimensions.common.machine.PopMode;
+import com.wintercogs.beyonddimensions.common.machine.RedStoneControlMode;
+
+public interface NetInterfaceAccess
+{
+    StackHandler getStackHandler();
+
+    StackHandler getFakeStackHandler();
+
+    NetInterfaceSettings getNetInterfaceSettings();
+
+    default PopMode getPopMode()
+    {
+        return getNetInterfaceSettings().getPopMode();
+    }
+
+    default void setPopMode(PopMode popMode)
+    {
+        getNetInterfaceSettings().setPopMode(popMode);
+    }
+
+    default FuzzyMode getFuzzyMode()
+    {
+        return getNetInterfaceSettings().getFuzzyMode();
+    }
+
+    default void setFuzzyMode(FuzzyMode fuzzyMode)
+    {
+        getNetInterfaceSettings().setFuzzyMode(fuzzyMode);
+    }
+
+    RedStoneControlMode getControlMode();
+
+    void setControlMode(RedStoneControlMode controlMode);
+
+    default boolean canConfigurePopMode()
+    {
+        return true;
+    }
+
+    boolean isMenuValid();
+
+    void onMenuDataChanged();
+
+    static boolean transferToNet(DimensionsNet net, StackHandler stackHandler, StackHandler fakeStackHandler, int slotCount)
+    {
+        if (net == null) return false;
+        boolean changed = false;
+        for (int i = 0; i < slotCount; i++)
+        {
+            KeyAmount flag = fakeStackHandler.getStackBySlot(i);
+            if (!flag.isEmpty() && flag.key().isSameTypeSameComponents(stackHandler.getStackBySlot(i).key()))
+                continue;
+            KeyAmount stack = stackHandler.getStackBySlot(i);
+            if (!stack.isEmpty())
+            {
+                KeyAmount extracted = stackHandler.extract(i, stack.amount(), false);
+                KeyAmount remaining = net.getUnifiedStorage().insert(extracted.key(), extracted.amount(), false);
+                if (!remaining.isEmpty())
+                    stackHandler.insert(i, remaining.key(), remaining.amount(), false);
+                changed |= remaining.amount() != extracted.amount();
+            }
+        }
+        return changed;
+    }
+
+    static boolean transferFromNet(DimensionsNet net, StackHandler stackHandler, StackHandler fakeStackHandler, int slotCount, FuzzyMode fuzzyMode)
+    {
+        if (net == null) return false;
+        boolean changed = false;
+        for (int i = 0; i < slotCount; i++)
+        {
+            KeyAmount flag = fakeStackHandler.getStackBySlot(i);
+            if (flag.isEmpty()) continue;
+            KeyAmount current = stackHandler.getStackBySlot(i);
+            if (!current.isEmpty() && !current.key().isSameTypeSameComponents(flag.key()))
+                continue;
+            long currentAmount = current.isEmpty() ? 0 : current.amount();
+            long missing = flag.key().getVanillaMaxStackSize() - currentAmount;
+            if (missing <= 0) continue;
+            KeyAmount stack = net.getUnifiedStorage().extract(flag.key(), missing, false, fuzzyMode == FuzzyMode.ENABLE);
+            if (!stack.isEmpty())
+            {
+                KeyAmount remaining = stackHandler.insert(i, stack.key(), stack.amount(), false);
+                if (!remaining.isEmpty())
+                    net.getUnifiedStorage().insert(remaining.key(), remaining.amount(), false);
+                changed |= remaining.amount() != stack.amount();
+            }
+        }
+        return changed;
+    }
+}

--- a/src/main/java/com/wintercogs/beyonddimensions/common/menu/NetInterfaceBaseMenu.java
+++ b/src/main/java/com/wintercogs/beyonddimensions/common/menu/NetInterfaceBaseMenu.java
@@ -3,15 +3,19 @@ package com.wintercogs.beyonddimensions.common.menu;
 import com.wintercogs.beyonddimensions.api.ids.BDConstants;
 import com.wintercogs.beyonddimensions.api.storage.handler.impl.StackHandler;
 import com.wintercogs.beyonddimensions.client.gui.CommonTextures;
-import com.wintercogs.beyonddimensions.common.block.entity.NetInterfaceBlockEntity;
 import com.wintercogs.beyonddimensions.common.machine.FuzzyMode;
 import com.wintercogs.beyonddimensions.common.machine.PopMode;
 import com.wintercogs.beyonddimensions.common.machine.RedStoneControlMode;
 import com.wintercogs.beyonddimensions.common.menu.widget.slot.FlagStackTypedSlot;
 import com.wintercogs.beyonddimensions.common.menu.widget.slot.OrderedStackTypedSlot;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.HolderLookup;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtOps;
+import net.minecraft.nbt.Tag;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.RegistryOps;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.MenuType;
@@ -33,11 +37,11 @@ public class NetInterfaceBaseMenu extends BDBaseMenu
     public final StackHandler storage;
     public final StackHandler flagStorage;
 
-    public NetInterfaceBlockEntity be;
+    private final NetInterfaceAccess access;
 
     // 构建注册用的信息
     public static final DeferredRegister<MenuType<?>> MENU_TYPES = DeferredRegister.create(Registries.MENU, BDConstants.MODID);
-    public static final Supplier<MenuType<NetInterfaceBaseMenu>> Net_Interface_Menu = MENU_TYPES.register("net_interface_menu", () -> IMenuTypeExtension.create(NetInterfaceBaseMenu::new));
+    public static final Supplier<MenuType<NetInterfaceBaseMenu>> Net_Interface_Menu = MENU_TYPES.register("net_interface_menu", () -> IMenuTypeExtension.create(NetInterfaceBaseMenu::fromNetwork));
 
 
     /**
@@ -47,7 +51,31 @@ public class NetInterfaceBaseMenu extends BDBaseMenu
      */
     public NetInterfaceBaseMenu(int id, Inventory playerInventory, FriendlyByteBuf data)
     {
-        this(id, playerInventory, (NetInterfaceBlockEntity) playerInventory.player.level().getBlockEntity(data.readBlockPos()));
+        this(id, playerInventory, data.readBlockPos());
+    }
+
+    private static NetInterfaceBaseMenu fromNetwork(int id, Inventory playerInventory, FriendlyByteBuf data)
+    {
+        if (data.readableBytes() == Long.BYTES)
+        {
+            return new NetInterfaceBaseMenu(id, playerInventory, data.readBlockPos());
+        }
+
+        if (data.readBoolean())
+        {
+            return NetInterfaceBaseMenu.mounted(id, playerInventory, data);
+        }
+        return new NetInterfaceBaseMenu(id, playerInventory, data.readBlockPos());
+    }
+
+    public static NetInterfaceBaseMenu mounted(int id, Inventory playerInventory, FriendlyByteBuf data)
+    {
+        return new NetInterfaceBaseMenu(id, playerInventory, new ClientAccess(playerInventory.player.level().registryAccess(), data));
+    }
+
+    public NetInterfaceBaseMenu(int id, Inventory playerInventory, BlockPos pos)
+    {
+        this(id, playerInventory, (NetInterfaceAccess) playerInventory.player.level().getBlockEntity(pos));
     }
 
     /**
@@ -55,20 +83,25 @@ public class NetInterfaceBaseMenu extends BDBaseMenu
      *
      * @param playerInventory 玩家背包
      */
-    public NetInterfaceBaseMenu(int id, Inventory playerInventory, NetInterfaceBlockEntity be)
+    public NetInterfaceBaseMenu(int id, Inventory playerInventory, NetInterfaceAccess access)
     {
         super(Net_Interface_Menu.get(), id, playerInventory);
 
         // 初始化标记容器（slot负责同步）
-        this.storage = be.getStackHandler();
-        this.flagStorage = be.getFakeStackHandler();
+        this.storage = access.getStackHandler();
+        this.flagStorage = access.getFakeStackHandler();
 
-        this.be = be;
+        this.access = access;
 
         addPlayerInv(playerInventory);
         addStorageSlots();
         addFlagSlots();
 
+    }
+
+    public NetInterfaceAccess getAccess()
+    {
+        return this.access;
     }
 
     private void addStorageSlots()
@@ -153,23 +186,29 @@ public class NetInterfaceBaseMenu extends BDBaseMenu
     protected void writeQuickDataTag(CompoundTag tag)
     {
         super.writeQuickDataTag(tag);
-        tag.putString("popMode", be.popMode.name());
-        tag.putString("controlMode", be.controlMode.name());
-        tag.putString("fuzzyMode", be.fuzzyMode.name());
+        tag.putString("popMode", access.getPopMode().name());
+        tag.putString("controlMode", access.getControlMode().name());
+        tag.putString("fuzzyMode", access.getFuzzyMode().name());
     }
 
     @Override
     public void readQuickDataTag(CompoundTag tag)
     {
         super.readQuickDataTag(tag);
-        be.popMode = PopMode.valueOf(tag.getString("popMode"));
-        be.controlMode = RedStoneControlMode.valueOf(tag.getString("controlMode"));
-        be.fuzzyMode = FuzzyMode.valueOf(tag.getString("fuzzyMode"));
+        if (access == null || !access.isMenuValid())
+        {
+            return;
+        }
+        if (access.canConfigurePopMode())
+        {
+            access.setPopMode(PopMode.valueOf(tag.getString("popMode")));
+        }
+        access.setControlMode(RedStoneControlMode.valueOf(tag.getString("controlMode")));
+        access.setFuzzyMode(FuzzyMode.valueOf(tag.getString("fuzzyMode")));
         // 服务端读取新数据之后利用sendBlockUpdated将数据发送给附近所有玩家
         if (!player.level().isClientSide())
         {
-            player.level().blockEntityChanged(be.getBlockPos());
-            player.level().sendBlockUpdated(be.getBlockPos(), be.getBlockState(), be.getBlockState(), 2);
+            access.onMenuDataChanged();
         }
     }
 
@@ -177,7 +216,84 @@ public class NetInterfaceBaseMenu extends BDBaseMenu
     @Override
     public boolean stillValid(@NotNull Player player)
     {
-        return be != null && !be.isRemoved();
+        return access != null && access.isMenuValid();
+    }
+
+    private static final class ClientAccess implements NetInterfaceAccess
+    {
+        private final StackHandler stackHandler;
+        private final StackHandler fakeStackHandler;
+        private final NetInterfaceSettings settings = new NetInterfaceSettings();
+        private RedStoneControlMode controlMode;
+
+        private ClientAccess(HolderLookup.Provider registries, FriendlyByteBuf data)
+        {
+            CompoundTag inventory = data.readNbt();
+            CompoundTag flags = data.readNbt();
+            this.stackHandler = decodeStackHandler(registries, inventory);
+            this.fakeStackHandler = decodeStackHandler(registries, flags);
+            settings.setPopMode(PopMode.valueOf(data.readUtf()));
+            settings.setFuzzyMode(FuzzyMode.valueOf(data.readUtf()));
+            this.controlMode = RedStoneControlMode.valueOf(data.readUtf());
+        }
+
+        @Override
+        public StackHandler getStackHandler()
+        {
+            return this.stackHandler;
+        }
+
+        @Override
+        public StackHandler getFakeStackHandler()
+        {
+            return this.fakeStackHandler;
+        }
+
+        @Override
+        public NetInterfaceSettings getNetInterfaceSettings()
+        {
+            return this.settings;
+        }
+
+        @Override
+        public RedStoneControlMode getControlMode()
+        {
+            return this.controlMode;
+        }
+
+        @Override
+        public void setControlMode(RedStoneControlMode controlMode)
+        {
+            this.controlMode = controlMode;
+        }
+
+        @Override
+        public boolean canConfigurePopMode()
+        {
+            return false;
+        }
+
+        @Override
+        public boolean isMenuValid()
+        {
+            return true;
+        }
+
+        @Override
+        public void onMenuDataChanged()
+        {
+        }
+
+        private static StackHandler decodeStackHandler(HolderLookup.Provider registries, CompoundTag tag)
+        {
+            if (tag == null)
+            {
+                return new StackHandler(0);
+            }
+            RegistryOps<Tag> ops = RegistryOps.create(NbtOps.INSTANCE, registries);
+            return StackHandler.CODEC.parse(ops, tag)
+                    .getOrThrow(IllegalStateException::new);
+        }
     }
 
 }

--- a/src/main/java/com/wintercogs/beyonddimensions/common/menu/NetInterfaceSettings.java
+++ b/src/main/java/com/wintercogs/beyonddimensions/common/menu/NetInterfaceSettings.java
@@ -1,0 +1,30 @@
+package com.wintercogs.beyonddimensions.common.menu;
+
+import com.wintercogs.beyonddimensions.common.machine.FuzzyMode;
+import com.wintercogs.beyonddimensions.common.machine.PopMode;
+
+public class NetInterfaceSettings
+{
+    private PopMode popMode = PopMode.STOP;
+    private FuzzyMode fuzzyMode = FuzzyMode.DISABLE;
+
+    public PopMode getPopMode()
+    {
+        return popMode;
+    }
+
+    public void setPopMode(PopMode popMode)
+    {
+        this.popMode = popMode;
+    }
+
+    public FuzzyMode getFuzzyMode()
+    {
+        return fuzzyMode;
+    }
+
+    public void setFuzzyMode(FuzzyMode fuzzyMode)
+    {
+        this.fuzzyMode = fuzzyMode;
+    }
+}

--- a/src/main/java/com/wintercogs/beyonddimensions/integration/module/create/CreateModule.java
+++ b/src/main/java/com/wintercogs/beyonddimensions/integration/module/create/CreateModule.java
@@ -1,9 +1,14 @@
 package com.wintercogs.beyonddimensions.integration.module.create;
 
+import com.simibubi.create.api.behaviour.movement.MovementBehaviour;
+import com.simibubi.create.api.contraption.storage.item.MountedItemStorageType;
+import com.wintercogs.beyonddimensions.common.init.BDBlocks;
 import com.wintercogs.beyonddimensions.integration.BDIntegrationModule;
 import com.wintercogs.beyonddimensions.integration.IIntegrationModule;
 import com.wintercogs.beyonddimensions.integration.OtherModIds;
 import com.wintercogs.beyonddimensions.integration.module.create.block.entity.SchematicannonPathWayBlockEntity;
+import com.wintercogs.beyonddimensions.integration.module.create.contraption.NetInterfaceMountedStorageType;
+import com.wintercogs.beyonddimensions.integration.module.create.contraption.NetInterfaceMovementBehaviour;
 import com.wintercogs.beyonddimensions.integration.module.create.datagen.CreateModuleBlockLootTableProvider;
 import com.wintercogs.beyonddimensions.integration.module.create.datagen.CreateModuleBlockStateProvider;
 import com.wintercogs.beyonddimensions.integration.module.create.datagen.CreateModuleRecipeProvider;
@@ -41,13 +46,23 @@ public class CreateModule implements IIntegrationModule
     {
         CreateModuleBlocks.register(modBus);
         CreateModuleBlockEntities.register(modBus);
+        NetInterfaceMountedStorageType.register(modBus);
         modBus.addListener(SchematicannonPathWayBlockEntity::registerCapability);
     }
 
     @Override
     public void onCommonSetup(FMLCommonSetupEvent event)
     {
-
+        event.enqueueWork(() -> {
+            MountedItemStorageType.REGISTRY.register(
+                    BDBlocks.NET_INTERFACE.get(),
+                    NetInterfaceMountedStorageType.NET_INTERFACE.get()
+            );
+            MovementBehaviour.REGISTRY.register(
+                    BDBlocks.NET_INTERFACE.get(),
+                    new NetInterfaceMovementBehaviour()
+            );
+        });
     }
 
     @Override

--- a/src/main/java/com/wintercogs/beyonddimensions/integration/module/create/contraption/NetInterfaceMountedStorage.java
+++ b/src/main/java/com/wintercogs/beyonddimensions/integration/module/create/contraption/NetInterfaceMountedStorage.java
@@ -1,0 +1,419 @@
+package com.wintercogs.beyonddimensions.integration.module.create.contraption;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import com.simibubi.create.api.contraption.storage.SyncedMountedStorage;
+import com.simibubi.create.api.contraption.storage.item.MountedItemStorage;
+import com.simibubi.create.api.contraption.storage.item.MountedItemStorageType;
+import com.simibubi.create.content.contraptions.Contraption;
+import com.wintercogs.beyonddimensions.api.dimensionnet.DimensionsNet;
+import com.wintercogs.beyonddimensions.api.storage.handler.impl.StackHandler;
+import com.wintercogs.beyonddimensions.api.storage.key.KeyAmount;
+import com.wintercogs.beyonddimensions.api.storage.key.impl.EmptyStackKey;
+import com.wintercogs.beyonddimensions.api.storage.key.impl.ItemStackKey;
+import com.wintercogs.beyonddimensions.common.block.entity.NetInterfaceBlockEntity;
+import com.wintercogs.beyonddimensions.common.machine.FuzzyMode;
+import com.wintercogs.beyonddimensions.common.machine.PopMode;
+import com.wintercogs.beyonddimensions.common.machine.RedStoneControlMode;
+import com.wintercogs.beyonddimensions.common.menu.NetInterfaceAccess;
+import com.wintercogs.beyonddimensions.common.menu.NetInterfaceSettings;
+import com.wintercogs.beyonddimensions.util.BDMath;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate.StructureBlockInfo;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.SimpleMenuProvider;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class NetInterfaceMountedStorage extends MountedItemStorage implements NetInterfaceAccess, SyncedMountedStorage
+{
+    private static final int DEFAULT_EMPTY_SLOT_LIMIT = 64;
+
+    private static final Codec<PopMode> POP_MODE_CODEC = Codec.STRING.xmap(PopMode::valueOf, PopMode::name);
+    private static final Codec<FuzzyMode> FUZZY_MODE_CODEC = Codec.STRING.xmap(FuzzyMode::valueOf, FuzzyMode::name);
+    private static final Codec<RedStoneControlMode> CONTROL_MODE_CODEC = Codec.STRING.xmap(RedStoneControlMode::valueOf, RedStoneControlMode::name);
+
+    public static final MapCodec<NetInterfaceMountedStorage> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
+            StackHandler.CODEC.fieldOf("inventory").forGetter(NetInterfaceMountedStorage::getStackHandler),
+            StackHandler.CODEC.fieldOf("flags").forGetter(NetInterfaceMountedStorage::getFakeStackHandler),
+            Codec.INT.fieldOf("net_id").forGetter(NetInterfaceMountedStorage::getNetId),
+            POP_MODE_CODEC.fieldOf("pop_mode").forGetter(NetInterfaceMountedStorage::getPopMode),
+            FUZZY_MODE_CODEC.fieldOf("fuzzy_mode").forGetter(NetInterfaceMountedStorage::getFuzzyMode),
+            CONTROL_MODE_CODEC.fieldOf("control_mode").forGetter(NetInterfaceMountedStorage::getControlMode),
+            Codec.INT.fieldOf("step_tick").forGetter(NetInterfaceMountedStorage::getStepTick)
+    ).apply(instance, NetInterfaceMountedStorage::new));
+
+    private final StackHandler stackHandler;
+    private final StackHandler fakeStackHandler;
+    private final int netId;
+    private final NetInterfaceSettings settings = new NetInterfaceSettings();
+    private RedStoneControlMode controlMode;
+    private int stepTick;
+    private boolean valid = true;
+    private boolean dirty;
+
+    public NetInterfaceMountedStorage(StackHandler stackHandler, StackHandler fakeStackHandler, int netId,
+                                      PopMode popMode, FuzzyMode fuzzyMode, RedStoneControlMode controlMode,
+                                      int stepTick)
+    {
+        this(NetInterfaceMountedStorageType.NET_INTERFACE.get(), stackHandler, fakeStackHandler, netId, popMode, fuzzyMode, controlMode, stepTick);
+    }
+
+    public NetInterfaceMountedStorage(MountedItemStorageType<?> type, StackHandler stackHandler, StackHandler fakeStackHandler,
+                                      int netId, PopMode popMode, FuzzyMode fuzzyMode, RedStoneControlMode controlMode,
+                                      int stepTick)
+    {
+        super(type);
+        this.stackHandler = stackHandler;
+        this.fakeStackHandler = fakeStackHandler;
+        this.netId = netId;
+        this.settings.setPopMode(popMode);
+        this.settings.setFuzzyMode(fuzzyMode);
+        this.controlMode = controlMode;
+        this.stepTick = stepTick;
+    }
+
+    @Override
+    public StackHandler getStackHandler()
+    {
+        return this.stackHandler;
+    }
+
+    @Override
+    public StackHandler getFakeStackHandler()
+    {
+        return this.fakeStackHandler;
+    }
+
+    public int getNetId()
+    {
+        return this.netId;
+    }
+
+    @Override
+    public NetInterfaceSettings getNetInterfaceSettings()
+    {
+        return this.settings;
+    }
+
+    @Override
+    public RedStoneControlMode getControlMode()
+    {
+        return this.controlMode;
+    }
+
+    @Override
+    public void setControlMode(RedStoneControlMode controlMode)
+    {
+        if (!this.valid)
+        {
+            return;
+        }
+        if (this.controlMode == controlMode)
+        {
+            return;
+        }
+        this.controlMode = controlMode;
+        markDirty();
+    }
+
+    @Override
+    public void setPopMode(PopMode popMode)
+    {
+        if (!this.valid)
+        {
+            return;
+        }
+        if (getPopMode() == popMode)
+        {
+            return;
+        }
+        NetInterfaceAccess.super.setPopMode(popMode);
+        markDirty();
+    }
+
+    @Override
+    public void setFuzzyMode(FuzzyMode fuzzyMode)
+    {
+        if (!this.valid)
+        {
+            return;
+        }
+        if (getFuzzyMode() == fuzzyMode)
+        {
+            return;
+        }
+        NetInterfaceAccess.super.setFuzzyMode(fuzzyMode);
+        markDirty();
+    }
+
+    @Override
+    public boolean canConfigurePopMode()
+    {
+        return false;
+    }
+
+    public int getStepTick()
+    {
+        return this.stepTick;
+    }
+
+    @Override
+    public boolean isMenuValid()
+    {
+        return this.valid;
+    }
+
+    @Override
+    public void onMenuDataChanged()
+    {
+        markDirty();
+    }
+
+    @Override
+    public boolean isDirty()
+    {
+        return this.dirty;
+    }
+
+    @Override
+    public void markClean()
+    {
+        this.dirty = false;
+    }
+
+    @Override
+    public void afterSync(Contraption contraption, BlockPos localPos)
+    {
+    }
+
+    @Override
+    public int getSlots()
+    {
+        return this.stackHandler.getSlots();
+    }
+
+    @Override
+    public @NotNull ItemStack getStackInSlot(int slot)
+    {
+        KeyAmount stack = this.stackHandler.getStackBySlot(slot);
+        return toItemStack(stack);
+    }
+
+    @Override
+    public void setStackInSlot(int slot, @NotNull ItemStack stack)
+    {
+        if (!this.valid)
+        {
+            return;
+        }
+        setItemStack(this.stackHandler, slot, stack);
+        markDirty();
+    }
+
+    @Override
+    public @NotNull ItemStack insertItem(int slot, @NotNull ItemStack stack, boolean simulate)
+    {
+        if (!this.valid)
+        {
+            return stack;
+        }
+        if (stack.isEmpty()) return ItemStack.EMPTY;
+        KeyAmount remaining = this.stackHandler.insert(slot, new ItemStackKey(stack), stack.getCount(), simulate);
+        if (!simulate && remaining.amount() != stack.getCount())
+        {
+            markDirty();
+        }
+        return toRemainingItemStack(remaining, stack);
+    }
+
+    @Override
+    public @NotNull ItemStack extractItem(int slot, int amount, boolean simulate)
+    {
+        if (!this.valid)
+        {
+            return ItemStack.EMPTY;
+        }
+        if (amount <= 0) return ItemStack.EMPTY;
+        KeyAmount extracted = this.stackHandler.extract(slot, amount, simulate);
+        if (!simulate && !extracted.isEmpty())
+        {
+            markDirty();
+        }
+        return toItemStack(extracted);
+    }
+
+    @Override
+    public int getSlotLimit(int slot)
+    {
+        KeyAmount stack = this.stackHandler.getStackBySlot(slot);
+        long byType = stack.isEmpty() ? DEFAULT_EMPTY_SLOT_LIMIT : stack.key().getVanillaMaxStackSize();
+        long byCap = this.stackHandler.getSlotCapacity(slot);
+        return BDMath.clampLongToInt(Math.min(byType, byCap));
+    }
+
+    @Override
+    public boolean isItemValid(int slot, @NotNull ItemStack stack)
+    {
+        return true;
+    }
+
+    public void tickCoreTransfer()
+    {
+        if (!this.valid)
+        {
+            return;
+        }
+        if (!shouldWorkMounted())
+        {
+            return;
+        }
+        if (transferToNetMounted() || transferFromNetMounted())
+        {
+            markDirty();
+        }
+    }
+
+    private void markDirty()
+    {
+        this.dirty = true;
+    }
+
+    private boolean shouldWorkMounted()
+    {
+        this.stepTick++;
+        if (this.stepTick < 9)
+        {
+            return false;
+        }
+        this.stepTick = 0;
+
+        return switch (this.controlMode)
+        {
+            case IGNORE, UNPOWERED -> true;
+            case NOT_WORKING, POWERED -> false;
+        };
+    }
+
+    private @Nullable DimensionsNet getMountedNet()
+    {
+        if (this.netId < 0)
+        {
+            return null;
+        }
+        DimensionsNet net = DimensionsNet.getNetFromId(this.netId);
+        return net != null && !net.deleted ? net : null;
+    }
+
+    private boolean transferToNetMounted()
+    {
+        return NetInterfaceAccess.transferToNet(getMountedNet(), stackHandler, fakeStackHandler, stackHandler.getSlots());
+    }
+
+    private boolean transferFromNetMounted()
+    {
+        return NetInterfaceAccess.transferFromNet(getMountedNet(), stackHandler, fakeStackHandler, stackHandler.getSlots(), getFuzzyMode());
+    }
+
+    @Override
+    public boolean handleInteraction(ServerPlayer player, Contraption contraption, StructureBlockInfo info)
+    {
+        player.openMenu(new SimpleMenuProvider(
+                (containerId, inventory, serverPlayer) -> new com.wintercogs.beyonddimensions.common.menu.NetInterfaceBaseMenu(containerId, inventory, this),
+                info.state().getBlock().getName()
+        ), buf -> {
+            buf.writeBoolean(true);
+            buf.writeNbt(this.stackHandler.serializeNBT(player.registryAccess()));
+            buf.writeNbt(this.fakeStackHandler.serializeNBT(player.registryAccess()));
+            buf.writeUtf(getPopMode().name());
+            buf.writeUtf(getFuzzyMode().name());
+            buf.writeUtf(this.controlMode.name());
+        });
+        return true;
+    }
+
+    @Override
+    public void unmount(Level level, BlockState state, BlockPos pos, @Nullable BlockEntity be)
+    {
+        this.valid = false;
+        if (be instanceof NetInterfaceBlockEntity netInterface)
+        {
+            copyInto(this.stackHandler, netInterface.getStackHandler());
+            copyInto(this.fakeStackHandler, netInterface.getFakeStackHandler());
+            netInterface.setPopMode(getPopMode());
+            netInterface.setFuzzyMode(getFuzzyMode());
+            netInterface.setControlMode(this.controlMode);
+            netInterface.setNeedsCapabilityUpdate();
+            netInterface.setChanged();
+            netInterface.onMenuDataChanged();
+        }
+    }
+
+    public static NetInterfaceMountedStorage fromBlockEntity(NetInterfaceBlockEntity be)
+    {
+        return new NetInterfaceMountedStorage(
+                copyOf(be.getStackHandler()),
+                copyOf(be.getFakeStackHandler()),
+                be.getNetId(),
+                be.getPopMode(),
+                be.getFuzzyMode(),
+                be.getControlMode(),
+                be.getStepTick()
+        );
+    }
+
+    private static StackHandler copyOf(StackHandler source)
+    {
+        StackHandler copy = new StackHandler(source.getSlots());
+        copyInto(source, copy);
+        return copy;
+    }
+
+    private static void copyInto(StackHandler source, StackHandler target)
+    {
+        int slots = Math.min(source.getSlots(), target.getSlots());
+        for (int i = 0; i < slots; i++)
+        {
+            KeyAmount stack = source.getStackBySlot(i);
+            target.setStackDirectly(i, stack.key(), stack.amount());
+        }
+        for (int i = slots; i < target.getSlots(); i++)
+        {
+            target.setStackDirectly(i, EmptyStackKey.INSTANCE, 0);
+        }
+    }
+
+    private static ItemStack toItemStack(KeyAmount stack)
+    {
+        Object out = stack.toStack();
+        return out instanceof ItemStack itemStack ? itemStack : ItemStack.EMPTY;
+    }
+
+    private static ItemStack toRemainingItemStack(KeyAmount remaining, ItemStack fallback)
+    {
+        if (remaining.isEmpty())
+        {
+            return ItemStack.EMPTY;
+        }
+
+        Object out = remaining.toStack();
+        return out instanceof ItemStack itemStack ? itemStack : fallback.copy();
+    }
+
+    private static void setItemStack(StackHandler handler, int slot, ItemStack stack)
+    {
+        if (stack.isEmpty())
+        {
+            handler.setStackDirectly(slot, EmptyStackKey.INSTANCE, 0);
+            return;
+        }
+
+        ItemStack copy = stack.copy();
+        handler.setStackDirectly(slot, new ItemStackKey(copy), copy.getCount());
+    }
+}

--- a/src/main/java/com/wintercogs/beyonddimensions/integration/module/create/contraption/NetInterfaceMountedStorageType.java
+++ b/src/main/java/com/wintercogs/beyonddimensions/integration/module/create/contraption/NetInterfaceMountedStorageType.java
@@ -1,0 +1,40 @@
+package com.wintercogs.beyonddimensions.integration.module.create.contraption;
+
+import com.simibubi.create.api.contraption.storage.item.MountedItemStorageType;
+import com.simibubi.create.api.registry.CreateRegistries;
+import com.wintercogs.beyonddimensions.api.ids.BDConstants;
+import com.wintercogs.beyonddimensions.common.block.entity.NetInterfaceBlockEntity;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.neoforge.registries.DeferredHolder;
+import net.neoforged.neoforge.registries.DeferredRegister;
+import org.jetbrains.annotations.Nullable;
+
+public class NetInterfaceMountedStorageType extends MountedItemStorageType<NetInterfaceMountedStorage>
+{
+    public static final DeferredRegister<MountedItemStorageType<?>> TYPES = DeferredRegister.create(CreateRegistries.MOUNTED_ITEM_STORAGE_TYPE, BDConstants.MODID);
+    public static final DeferredHolder<MountedItemStorageType<?>, NetInterfaceMountedStorageType> NET_INTERFACE = TYPES.register("net_interface", NetInterfaceMountedStorageType::new);
+
+    public static void register(IEventBus modBus)
+    {
+        TYPES.register(modBus);
+    }
+
+    public NetInterfaceMountedStorageType()
+    {
+        super(NetInterfaceMountedStorage.CODEC);
+    }
+
+    @Override
+    public @Nullable NetInterfaceMountedStorage mount(Level level, BlockState state, BlockPos pos, @Nullable BlockEntity be)
+    {
+        if (be instanceof NetInterfaceBlockEntity netInterface)
+        {
+            return NetInterfaceMountedStorage.fromBlockEntity(netInterface);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/wintercogs/beyonddimensions/integration/module/create/contraption/NetInterfaceMovementBehaviour.java
+++ b/src/main/java/com/wintercogs/beyonddimensions/integration/module/create/contraption/NetInterfaceMovementBehaviour.java
@@ -1,0 +1,23 @@
+package com.wintercogs.beyonddimensions.integration.module.create.contraption;
+
+import com.simibubi.create.api.behaviour.movement.MovementBehaviour;
+import com.simibubi.create.api.contraption.storage.item.MountedItemStorage;
+import com.simibubi.create.content.contraptions.behaviour.MovementContext;
+
+public class NetInterfaceMovementBehaviour implements MovementBehaviour
+{
+    @Override
+    public void tick(MovementContext context)
+    {
+        if (context.world.isClientSide())
+        {
+            return;
+        }
+
+        MountedItemStorage storage = context.getItemStorage();
+        if (storage instanceof NetInterfaceMountedStorage netInterface)
+        {
+            netInterface.tickCoreTransfer();
+        }
+    }
+}

--- a/src/main/resources/assets/beyonddimensions/lang/de_de.json
+++ b/src/main/resources/assets/beyonddimensions/lang/de_de.json
@@ -53,6 +53,7 @@
   "tooltip.button.beyonddimensions.craft_toggle": "Crafting-Slot ein/ausblenden",
   "tooltip.button.beyonddimensions.popmode_off": "Aktuell: Pop-up-Modus deaktiviert",
   "tooltip.button.beyonddimensions.popmode_on": "Aktuell: Pop-up-Modus aktiviert",
+  "tooltip.button.beyonddimensions.popmode_mounted_unavailable": "Pop-up-Modus ist auf bewegten Konstruktionen nicht verfugbar",
   "tooltip.button.beyonddimensions.filter_mode_ignore": "Aktuell: Filter ignorieren",
   "tooltip.button.beyonddimensions.filter_mode_white": "Aktuell: Whitelist-Modus",
   "tooltip.button.beyonddimensions.filter_mode_black": "Aktuell: Blacklist-Modus",

--- a/src/main/resources/assets/beyonddimensions/lang/en_us.json
+++ b/src/main/resources/assets/beyonddimensions/lang/en_us.json
@@ -56,6 +56,7 @@
   "tooltip.button.beyonddimensions.craft_toggle": "Toggle crafting slot visibility",
   "tooltip.button.beyonddimensions.popmode_off": "Current: Popup mode disabled",
   "tooltip.button.beyonddimensions.popmode_on": "Current: Popup mode enabled",
+  "tooltip.button.beyonddimensions.popmode_mounted_unavailable": "Popup mode is unavailable on moving contraptions",
   "tooltip.button.beyonddimensions.filter_mode_ignore": "Current: Ignore Filter",
   "tooltip.button.beyonddimensions.filter_mode_white": "Current: Whitelist Mode",
   "tooltip.button.beyonddimensions.filter_mode_black": "Current: Blacklist Mode",

--- a/src/main/resources/assets/beyonddimensions/lang/es_es.json
+++ b/src/main/resources/assets/beyonddimensions/lang/es_es.json
@@ -53,6 +53,7 @@
   "tooltip.button.beyonddimensions.craft_toggle": "Alternar slot de fabricación",
   "tooltip.button.beyonddimensions.popmode_off": "Actual: Modo emergente desactivado",
   "tooltip.button.beyonddimensions.popmode_on": "Actual: Modo emergente activado",
+  "tooltip.button.beyonddimensions.popmode_mounted_unavailable": "El modo emergente no esta disponible en artilugios en movimiento",
   "tooltip.button.beyonddimensions.filter_mode_ignore": "Actual: Ignorar filtro",
   "tooltip.button.beyonddimensions.filter_mode_white": "Actual: Modo lista blanca",
   "tooltip.button.beyonddimensions.filter_mode_black": "Actual: Modo lista negra",

--- a/src/main/resources/assets/beyonddimensions/lang/fr_fr.json
+++ b/src/main/resources/assets/beyonddimensions/lang/fr_fr.json
@@ -53,6 +53,7 @@
   "tooltip.button.beyonddimensions.craft_toggle": "Basculer slot de craft",
   "tooltip.button.beyonddimensions.popmode_off": "Actuel : Mode popup désactivé",
   "tooltip.button.beyonddimensions.popmode_on": "Actuel : Mode popup activé",
+  "tooltip.button.beyonddimensions.popmode_mounted_unavailable": "Le mode popup n'est pas disponible sur les contraptions en mouvement",
   "tooltip.button.beyonddimensions.filter_mode_ignore": "Actuel : Ignorer filtre",
   "tooltip.button.beyonddimensions.filter_mode_white": "Actuel : Mode liste blanche",
   "tooltip.button.beyonddimensions.filter_mode_black": "Actuel : Mode liste noire",

--- a/src/main/resources/assets/beyonddimensions/lang/ja_jp.json
+++ b/src/main/resources/assets/beyonddimensions/lang/ja_jp.json
@@ -53,6 +53,7 @@
   "tooltip.button.beyonddimensions.craft_toggle": "クラフトスロット表示切替",
   "tooltip.button.beyonddimensions.popmode_off": "現在：ポップアップ無効",
   "tooltip.button.beyonddimensions.popmode_on": "現在：ポップアップ有効",
+  "tooltip.button.beyonddimensions.popmode_mounted_unavailable": "移動中の構造物ではポップアップモードを使用できません",
   "tooltip.button.beyonddimensions.filter_mode_ignore": "現在：フィルター無視",
   "tooltip.button.beyonddimensions.filter_mode_white": "現在：ホワイトリストモード",
   "tooltip.button.beyonddimensions.filter_mode_black": "現在：ブラックリストモード",

--- a/src/main/resources/assets/beyonddimensions/lang/ko_kr.json
+++ b/src/main/resources/assets/beyonddimensions/lang/ko_kr.json
@@ -53,6 +53,7 @@
   "tooltip.button.beyonddimensions.craft_toggle": "제작 슬롯 표시 전환",
   "tooltip.button.beyonddimensions.popmode_off": "현재: 팝업 모드 비활성",
   "tooltip.button.beyonddimensions.popmode_on": "현재: 팝업 모드 활성",
+  "tooltip.button.beyonddimensions.popmode_mounted_unavailable": "움직이는 구조물에서는 팝업 모드를 사용할 수 없습니다",
   "tooltip.button.beyonddimensions.filter_mode_ignore": "현재: 필터 무시",
   "tooltip.button.beyonddimensions.filter_mode_white": "현재: 허용 목록 모드",
   "tooltip.button.beyonddimensions.filter_mode_black": "현재: 차단 목록 모드",

--- a/src/main/resources/assets/beyonddimensions/lang/pt_br.json
+++ b/src/main/resources/assets/beyonddimensions/lang/pt_br.json
@@ -53,6 +53,7 @@
   "tooltip.button.beyonddimensions.craft_toggle": "Alternar slot de crafting",
   "tooltip.button.beyonddimensions.popmode_off": "Atual: Modo popup desativado",
   "tooltip.button.beyonddimensions.popmode_on": "Atual: Modo popup ativado",
+  "tooltip.button.beyonddimensions.popmode_mounted_unavailable": "O modo popup nao esta disponivel em engenhocas em movimento",
   "tooltip.button.beyonddimensions.filter_mode_ignore": "Atual: Ignorar filtro",
   "tooltip.button.beyonddimensions.filter_mode_white": "Atual: Modo lista branca",
   "tooltip.button.beyonddimensions.filter_mode_black": "Atual: Modo lista negra",

--- a/src/main/resources/assets/beyonddimensions/lang/ru_ru.json
+++ b/src/main/resources/assets/beyonddimensions/lang/ru_ru.json
@@ -53,6 +53,7 @@
   "tooltip.button.beyonddimensions.craft_toggle": "Переключить слот крафта",
   "tooltip.button.beyonddimensions.popmode_off": "Режим всплывающих окон выключен",
   "tooltip.button.beyonddimensions.popmode_on": "Режим всплывающих окон включен",
+  "tooltip.button.beyonddimensions.popmode_mounted_unavailable": "Режим всплывающих окон недоступен на движущихся механизмах",
   "tooltip.button.beyonddimensions.filter_mode_ignore": "Текущий: Игнорировать фильтр",
   "tooltip.button.beyonddimensions.filter_mode_white": "Текущий: Белый список",
   "tooltip.button.beyonddimensions.filter_mode_black": "Текущий: Чёрный список",

--- a/src/main/resources/assets/beyonddimensions/lang/zh_cn.json
+++ b/src/main/resources/assets/beyonddimensions/lang/zh_cn.json
@@ -56,6 +56,7 @@
   "tooltip.button.beyonddimensions.craft_toggle": "切换合成槽 显示/隐藏",
   "tooltip.button.beyonddimensions.popmode_off": "当前：弹出模式关闭",
   "tooltip.button.beyonddimensions.popmode_on": "当前：弹出模式启用",
+  "tooltip.button.beyonddimensions.popmode_mounted_unavailable": "动态结构中不可使用弹出模式",
   "tooltip.button.beyonddimensions.filter_mode_ignore": "当前：忽略过滤",
   "tooltip.button.beyonddimensions.filter_mode_white": "当前：白名单模式",
   "tooltip.button.beyonddimensions.filter_mode_black": "当前：黑名单模式",

--- a/src/main/resources/assets/beyonddimensions/lang/zh_tw.json
+++ b/src/main/resources/assets/beyonddimensions/lang/zh_tw.json
@@ -56,6 +56,7 @@
   "tooltip.button.beyonddimensions.craft_toggle": "切換合成槽 顯示/隱藏",
   "tooltip.button.beyonddimensions.popmode_off": "目前：彈出模式關閉",
   "tooltip.button.beyonddimensions.popmode_on": "目前：彈出模式啟用",
+  "tooltip.button.beyonddimensions.popmode_mounted_unavailable": "動態結構中不可使用彈出模式",
   "tooltip.button.beyonddimensions.filter_mode_ignore": "目前：忽略過濾",
   "tooltip.button.beyonddimensions.filter_mode_white": "目前：白名單模式",
   "tooltip.button.beyonddimensions.filter_mode_black": "目前：黑名單模式",


### PR DESCRIPTION
使网络接口可以在机械动力的动态结构状态移动、同步和卸载中运行和使用

为了让GUI可以在mounted storage中打开, 抽象了NetInterfaceAccess接口，让NetInterfaceBaseMenu可以同时服务NetInterfaceBlockEntity和NetInterfaceMountedStorage

- 新增NetInterfaceSettings类来存储网络接口的设置从而复用代码

- 新增NetInterfaceMountedStorageType，负责将世界中的NetInterfaceBlockEntity转换为 mounted storage

- 新增NetInterfaceMovementBehaviour，用于在动态结构移动期间 tick NetInterfaceMountedStorage

AI披露: 使用GPT-5.5完成i18n、部分代码编写以及审阅


在Neoforge 21.1.219 服务器场景中测试运行正常