### PR TITLE
修复与 Botania 454 快照的兼容性（能力 API 重构导致 NoSuchFieldError）

### DIFF
--- a/src/main/java/com/wintercogs/beyonddimensions/integration/module/botania/BDBotaniaPlugin.java
+++ b/src/main/java/com/wintercogs/beyonddimensions/integration/module/botania/BDBotaniaPlugin.java
@@ -7,7 +7,6 @@ import com.wintercogs.beyonddimensions.common.menu.widget.slot.ItemCapInteractio
 import com.wintercogs.beyonddimensions.integration.module.botania.storage.ManaStackTypedHandler;
 import com.wintercogs.beyonddimensions.integration.module.botania.storage.ManaUnifiedStorageHandler;
 import net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent;
-import vazkii.botania.api.BotaniaForgeCapabilities;
 import vazkii.botania.common.item.BotaniaItems;
 
 /**
@@ -23,7 +22,7 @@ public class BDBotaniaPlugin
     public static void registerCapability(RegisterCapabilitiesEvent event)
     {
         event.registerBlockEntity(
-                BotaniaForgeCapabilities.SPARK_ATTACHABLE,
+                BotaniaCapabilityCompat.sparkAttachable(),
                 BDBlockEntities.NET_PATHWAY_BLOCK_ENTITY.get(),
                 (be, side) -> {
                     DimensionsNet net = be.getNet();
@@ -36,7 +35,7 @@ public class BDBotaniaPlugin
         );
 
         event.registerBlockEntity(
-                BotaniaForgeCapabilities.SPARK_ATTACHABLE,
+                BotaniaCapabilityCompat.sparkAttachable(),
                 BDBlockEntities.NET_INTERFACE_BLOCK_ENTITY.get(),
                 (be, side) -> {
                     return new ManaStackTypedHandler(be.getStackHandler(), new CapCtx(be.getLevel(), be.getBlockPos(), be));

--- a/src/main/java/com/wintercogs/beyonddimensions/integration/module/botania/BotaniaCapabilityCompat.java
+++ b/src/main/java/com/wintercogs/beyonddimensions/integration/module/botania/BotaniaCapabilityCompat.java
@@ -1,0 +1,134 @@
+package com.wintercogs.beyonddimensions.integration.module.botania;
+
+import net.minecraft.core.Direction;
+import net.neoforged.neoforge.capabilities.BlockCapability;
+import net.neoforged.neoforge.capabilities.ItemCapability;
+import vazkii.botania.api.BotaniaForgeCapabilities;
+import vazkii.botania.api.block.WandHUD;
+import vazkii.botania.api.block.Wandable;
+import vazkii.botania.api.mana.ManaItem;
+import vazkii.botania.api.mana.ManaReceiver;
+import vazkii.botania.api.mana.spark.SparkAttachable;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+/**
+ * 兼容新旧两套 Botania 能力（capability）暴露方式。
+ *
+ * <p>Botania 454 快照重构了能力 API：原先直接挂在 {@code BotaniaForgeCapabilities} 上的
+ * {@code MANA_RECEIVER}/{@code MANA_ITEM}/{@code SPARK_ATTACHABLE}/{@code WANDABLE}
+ * 以及 {@code BotaniaForgeClientCapabilities.BLOCK_WAND_HUD} 等字段被移除，改为各接口上的
+ * {@code LOOKUP}（如 {@code ManaReceiver.LOOKUP}），再经
+ * {@code BotaniaForgeCapabilities.getBlockApiLookupById(...)} / {@code getItemApiLookupById(...)}
+ * 转换为 NeoForge 的能力对象。
+ *
+ * <p>为同时兼容新旧 Botania（任一版本上都不抛 {@link NoSuchFieldError}），此处全部用反射在运行时
+ * 探测：优先尝试新 API，失败再回退到旧字段。涉及的接口类型（{@link ManaReceiver} 等）本身在新旧版本
+ * 都存在，因此可直接引用；只有“能力字段所在位置”随版本变化，故仅对位置做反射。
+ */
+public final class BotaniaCapabilityCompat
+{
+    private static final String API = "vazkii.botania.api.capability.";
+    private static final String OLD = "vazkii.botania.api.BotaniaForgeCapabilities";
+    private static final String OLD_CLIENT = "vazkii.botania.api.BotaniaForgeClientCapabilities";
+
+    private BotaniaCapabilityCompat() {}
+
+    @SuppressWarnings("unchecked")
+    public static BlockCapability<ManaReceiver, Direction> manaReceiver()
+    {
+        return (BlockCapability<ManaReceiver, Direction>) resolveBlock(
+                "vazkii.botania.api.mana.ManaReceiver", "LOOKUP", OLD, "MANA_RECEIVER");
+    }
+
+    @SuppressWarnings("unchecked")
+    public static ItemCapability<ManaItem, Void> manaItem()
+    {
+        return (ItemCapability<ManaItem, Void>) resolveItem(
+                "vazkii.botania.api.mana.ManaItem", "LOOKUP", OLD, "MANA_ITEM");
+    }
+
+    @SuppressWarnings("unchecked")
+    public static BlockCapability<SparkAttachable, Void> sparkAttachable()
+    {
+        return (BlockCapability<SparkAttachable, Void>) resolveBlock(
+                "vazkii.botania.api.mana.spark.SparkAttachable", "LOOKUP", OLD, "SPARK_ATTACHABLE");
+    }
+
+    @SuppressWarnings("unchecked")
+    public static BlockCapability<Wandable, Direction> wandable()
+    {
+        return (BlockCapability<Wandable, Direction>) resolveBlock(
+                "vazkii.botania.api.block.Wandable", "LOOKUP", OLD, "WANDABLE");
+    }
+
+    @SuppressWarnings("unchecked")
+    public static BlockCapability<WandHUD, Void> blockWandHud()
+    {
+        return (BlockCapability<WandHUD, Void>) resolveBlock(
+                "vazkii.botania.api.block.WandHUD", "BLOCK_LOOKUP", OLD_CLIENT, "BLOCK_WAND_HUD");
+    }
+
+    private static BlockCapability<?, ?> resolveBlock(String newHolder, String newField, String oldHolder, String oldField)
+    {
+        // 新 API：接口上的 LOOKUP -> getBlockApiLookupById(...)
+        try
+        {
+            Object lookup = field(newHolder, newField);
+            Class<?> withCtx = Class.forName(API + "BlockApiWithContext");
+            Class<?> param = withCtx.isInstance(lookup) ? withCtx : Class.forName(API + "BlockApiNoContext");
+            Method getById = BotaniaForgeCapabilities.class.getMethod("getBlockApiLookupById", param);
+            return (BlockCapability<?, ?>) getById.invoke(null, lookup);
+        }
+        catch (ReflectiveOperationException ignored)
+        {
+            // 旧 Botania 上没有 LOOKUP / 转换方法，落到旧字段
+        }
+
+        // 旧 API：直接挂在 capabilities 类上的字段
+        try
+        {
+            return (BlockCapability<?, ?>) field(oldHolder, oldField);
+        }
+        catch (ReflectiveOperationException e)
+        {
+            throw new IllegalStateException(
+                    "Beyond Dimensions: 无法在当前 Botania 版本上解析方块能力 " + newField, e);
+        }
+    }
+
+    private static ItemCapability<?, ?> resolveItem(String newHolder, String newField, String oldHolder, String oldField)
+    {
+        // 新 API：接口上的 LOOKUP -> getItemApiLookupById(...)
+        try
+        {
+            Object lookup = field(newHolder, newField);
+            Class<?> withCtx = Class.forName(API + "ItemApiWithContext");
+            Class<?> param = withCtx.isInstance(lookup) ? withCtx : Class.forName(API + "ItemApiNoContext");
+            Method getById = BotaniaForgeCapabilities.class.getMethod("getItemApiLookupById", param);
+            return (ItemCapability<?, ?>) getById.invoke(null, lookup);
+        }
+        catch (ReflectiveOperationException ignored)
+        {
+            // 旧 Botania 上没有 LOOKUP / 转换方法，落到旧字段
+        }
+
+        // 旧 API：直接挂在 capabilities 类上的字段
+        try
+        {
+            return (ItemCapability<?, ?>) field(oldHolder, oldField);
+        }
+        catch (ReflectiveOperationException e)
+        {
+            throw new IllegalStateException(
+                    "Beyond Dimensions: 无法在当前 Botania 版本上解析物品能力 " + newField, e);
+        }
+    }
+
+    private static Object field(String className, String fieldName) throws ReflectiveOperationException
+    {
+        Field f = Class.forName(className).getField(fieldName);
+        return f.get(null);
+    }
+}

--- a/src/main/java/com/wintercogs/beyonddimensions/integration/module/botania/BotaniaModule.java
+++ b/src/main/java/com/wintercogs/beyonddimensions/integration/module/botania/BotaniaModule.java
@@ -29,7 +29,6 @@ import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.neoforged.neoforge.common.data.ExistingFileHelper;
 import net.neoforged.neoforge.data.event.GatherDataEvent;
 import org.jetbrains.annotations.NotNull;
-import vazkii.botania.api.BotaniaForgeCapabilities;
 
 import java.util.Collections;
 import java.util.List;
@@ -59,8 +58,8 @@ public class BotaniaModule implements IIntegrationModule
     public void onCommonSetup(FMLCommonSetupEvent event)
     {
         StackKeyRegistry.registerType(ManaStackKey.INSTANCE);
-        CapabilityHelper.BlockCapabilityMap.put(ManaStackKey.ID, BotaniaForgeCapabilities.MANA_RECEIVER);
-        CapabilityHelper.ItemCapabilityMap.put(ManaStackKey.ID, BotaniaForgeCapabilities.MANA_ITEM);
+        CapabilityHelper.BlockCapabilityMap.put(ManaStackKey.ID, BotaniaCapabilityCompat.manaReceiver());
+        CapabilityHelper.ItemCapabilityMap.put(ManaStackKey.ID, BotaniaCapabilityCompat.manaItem());
         CapabilityHelper.registerUSHandler(ManaStackKey.INSTANCE, ManaUnifiedStorageHandler::new);
         CapabilityHelper.registerStackTypedHandler(ManaStackKey.INSTANCE, ManaStackTypedHandler::new);
         StackHandlerWrapperHelper.stackWrappers.put(ManaStackKey.ID, ManaHandlerWrapper::new);

--- a/src/main/java/com/wintercogs/beyonddimensions/integration/module/botania/block/entity/ManaPoolPathwayBlockEntity.java
+++ b/src/main/java/com/wintercogs/beyonddimensions/integration/module/botania/block/entity/ManaPoolPathwayBlockEntity.java
@@ -4,6 +4,7 @@ import com.mojang.blaze3d.platform.Window;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.wintercogs.beyonddimensions.api.util.CapCtx;
 import com.wintercogs.beyonddimensions.common.block.entity.NetedBlockEntity;
+import com.wintercogs.beyonddimensions.integration.module.botania.BotaniaCapabilityCompat;
 import com.wintercogs.beyonddimensions.integration.module.botania.init.BotaniaModuleBlockEntities;
 import com.wintercogs.beyonddimensions.integration.module.botania.storage.ManaUnifiedStorageHandler;
 import com.wintercogs.beyonddimensions.util.BDMath;
@@ -37,8 +38,6 @@ import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.UnknownNullability;
 import org.lwjgl.opengl.GL11;
 import vazkii.botania.api.BotaniaAPIClient;
-import vazkii.botania.api.BotaniaForgeCapabilities;
-import vazkii.botania.api.BotaniaForgeClientCapabilities;
 import vazkii.botania.api.block.WandHUD;
 import vazkii.botania.api.block.Wandable;
 import vazkii.botania.api.internal.ManaBurst;
@@ -140,25 +139,25 @@ public class ManaPoolPathwayBlockEntity extends NetedBlockEntity
     public static void registerCapability(RegisterCapabilitiesEvent event)
     {
         event.registerBlockEntity(
-                BotaniaForgeCapabilities.MANA_RECEIVER,
+                BotaniaCapabilityCompat.manaReceiver(),
                 BotaniaModuleBlockEntities.MANA_POOL_PATHWAY_BLOCK_ENTITY.get(),
                 (be, side) -> be instanceof ManaPoolPathwayBlockEntity pool ? pool : null
         );
 
         event.registerBlockEntity(
-                BotaniaForgeCapabilities.SPARK_ATTACHABLE,
+                BotaniaCapabilityCompat.sparkAttachable(),
                 BotaniaModuleBlockEntities.MANA_POOL_PATHWAY_BLOCK_ENTITY.get(),
                 (be, side) -> be instanceof ManaPoolPathwayBlockEntity pool ? pool : null
         );
 
         event.registerBlockEntity(
-                BotaniaForgeClientCapabilities.BLOCK_WAND_HUD,
+                BotaniaCapabilityCompat.blockWandHud(),
                 BotaniaModuleBlockEntities.MANA_POOL_PATHWAY_BLOCK_ENTITY.get(),
                 (be, side) -> be instanceof ManaPoolPathwayBlockEntity pool ? new WandHud(pool) : null
         );
 
         event.registerBlockEntity(
-                BotaniaForgeCapabilities.WANDABLE,
+                BotaniaCapabilityCompat.wandable(),
                 BotaniaModuleBlockEntities.MANA_POOL_PATHWAY_BLOCK_ENTITY.get(),
                 (be, side) -> be instanceof ManaPoolPathwayBlockEntity pool ? pool : null
         );


### PR DESCRIPTION
## 背景

关联 #51。Botania `454-SNAPSHOT` 重构了能力（capability）暴露方式：

- `BotaniaForgeCapabilities` 上的 `MANA_RECEIVER` / `MANA_ITEM` / `SPARK_ATTACHABLE` / `WANDABLE` 字段被**移除**；
- `BotaniaForgeClientCapabilities` 类（含 `BLOCK_WAND_HUD`）被**整体删除**；
- 改为挂在各接口上的 `LOOKUP`（如 `ManaReceiver.LOOKUP`、`WandHUD.BLOCK_LOOKUP`），需再经 `BotaniaForgeCapabilities.getBlockApiLookupById(...)` / `getItemApiLookupById(...)` 转换为 NeoForge 的 `BlockCapability` / `ItemCapability`。

当前代码直接引用旧字段，在新 Botania 上加载即抛：

```
java.lang.NoSuchFieldError: Class vazkii.botania.api.BotaniaForgeCapabilities
    does not have member field '...BlockCapability MANA_RECEIVER'
    at ...botania.BotaniaModule.onCommonSetup(BotaniaModule.java:62)
```

崩在 `MANA_RECEIVER` 只是第一个；`RegisterCapabilitiesEvent` 阶段的 `SPARK_ATTACHABLE` / `WANDABLE` / `BLOCK_WAND_HUD` 引用同样会崩。

## 改动

新增 `BotaniaCapabilityCompat`，用反射在运行时解析这些能力：**优先走新 API**（接口上的 `LOOKUP` → `getXxxApiLookupById(...)`），失败再**回退旧字段**。涉及的接口类型（`ManaReceiver`、`ManaItem`、`SparkAttachable`、`Wandable`、`WandHUD`）本身在新旧 Botania 都存在，故可直接引用；只对“能力字段所在位置”做反射。

其余改动仅把 3 处对旧字段的直接引用替换为该工具的调用（`BotaniaModule`、`BDBotaniaPlugin`、`ManaPoolPathwayBlockEntity`），**不改动任何业务逻辑**，也未改动构建依赖版本。

| 旧引用 | 新 API |
|---|---|
| `BotaniaForgeCapabilities.MANA_RECEIVER` | `ManaReceiver.LOOKUP` |
| `BotaniaForgeCapabilities.MANA_ITEM` | `ManaItem.LOOKUP` |
| `BotaniaForgeCapabilities.SPARK_ATTACHABLE` | `SparkAttachable.LOOKUP` |
| `BotaniaForgeCapabilities.WANDABLE` | `Wandable.LOOKUP` |
| `BotaniaForgeClientCapabilities.BLOCK_WAND_HUD` | `WandHUD.BLOCK_LOOKUP` |

## 兼容性

- **新版 Botania（≥454）**：走 `LOOKUP` 路径，不再 `NoSuchFieldError`。
- **旧版 Botania**：`LOOKUP` 字段不存在 → 反射回退到旧字段，行为与改动前完全一致。

即同一份 jar 在新旧 Botania 上都能正常加载。

## 验证

已将 `BotaniaCapabilityCompat` 对照 `botania-neoforge-1.21.1-454-SNAPSHOT` + NeoForge 21.1 单独 `javac` 编译通过，确认新 API 的字段类型与转换方法签名匹配（`BlockApiWithContext` / `BlockApiNoContext` / `ItemApiNoContext` 各自对应的 `getXxxApiLookupById` 重载）。
