### PR TITLE
修复 Botania 451/454 API 漂移兼容

### DIFF
--- a/src/main/java/com/wintercogs/beyonddimensions/common/block/entity/NetInterfaceBlockEntity.java
+++ b/src/main/java/com/wintercogs/beyonddimensions/common/block/entity/NetInterfaceBlockEntity.java
@@ -223,21 +223,26 @@ public class NetInterfaceBlockEntity extends BaseMachineBlockEntity implements M
 
         CapabilityHelper.BlockCapabilityMap.forEach(
                 (resourceLocation, directionBlockCapability) -> {
-                    CommonHandler handler = CapabilityHelper.CommonHandlerMap.get(resourceLocation);
-                    event.registerBlockEntity(
-                            (BlockCapability<? super Object, ? extends Direction>) directionBlockCapability,
-                            BDBlockEntities.NET_INTERFACE_BLOCK_ENTITY.get(),
-                            (be, side) -> {
-                                if (handler != null)
-                                {
-                                    if (handler.isContextual())
-                                        return handler.apply(be.stackHandler, new CapCtx(be.level, be.getBlockPos(), be));
-                                    else
-                                        return handler.apply(be.stackHandler, null);
-                                }
-                                return null; // 如果handler是null，那么必然返回null
-                            }
-                    );
+                    registerCapability(event, resourceLocation, directionBlockCapability);
+                }
+        );
+    }
+
+    public static void registerCapability(RegisterCapabilitiesEvent event, ResourceLocation resourceLocation, BlockCapability<?, Direction> directionBlockCapability)
+    {
+        CommonHandler handler = CapabilityHelper.CommonHandlerMap.get(resourceLocation);
+        event.registerBlockEntity(
+                (BlockCapability<? super Object, ? extends Direction>) directionBlockCapability,
+                BDBlockEntities.NET_INTERFACE_BLOCK_ENTITY.get(),
+                (be, side) -> {
+                    if (handler != null)
+                    {
+                        if (handler.isContextual())
+                            return handler.apply(be.stackHandler, new CapCtx(be.level, be.getBlockPos(), be));
+                        else
+                            return handler.apply(be.stackHandler, null);
+                    }
+                    return null; // 如果handler是null，那么必然返回null
                 }
         );
     }

--- a/src/main/java/com/wintercogs/beyonddimensions/common/block/entity/NetPathwayBlockEntity.java
+++ b/src/main/java/com/wintercogs/beyonddimensions/common/block/entity/NetPathwayBlockEntity.java
@@ -9,6 +9,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.neoforge.capabilities.BlockCapability;
 import net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent;
@@ -26,22 +27,27 @@ public class NetPathwayBlockEntity extends NetedBlockEntity
 
         CapabilityHelper.BlockCapabilityMap.forEach(
                 (resourceLocation, directionBlockCapability) -> {
-                    USHandler handler = CapabilityHelper.USHandlerMap.get(resourceLocation);
-                    event.registerBlockEntity(
-                            (BlockCapability<? super Object, ? extends Direction>) directionBlockCapability,
-                            BDBlockEntities.NET_PATHWAY_BLOCK_ENTITY.get(),
-                            (be, side) -> {
-                                DimensionsNet net = be.getNet(); // getNet已经在基类中完成缓存处理
-                                if (net != null && handler != null)
-                                {
-                                    if (handler.isContextual())
-                                        return handler.apply(net.getUnifiedStorage(), new CapCtx(be.level, be.getBlockPos(), be));
-                                    else
-                                        return handler.apply(net.getUnifiedStorage(), null);
-                                }
-                                return null;
-                            }
-                    );
+                    registerCapability(event, resourceLocation, directionBlockCapability);
+                }
+        );
+    }
+
+    public static void registerCapability(RegisterCapabilitiesEvent event, ResourceLocation resourceLocation, BlockCapability<?, Direction> directionBlockCapability)
+    {
+        USHandler handler = CapabilityHelper.USHandlerMap.get(resourceLocation);
+        event.registerBlockEntity(
+                (BlockCapability<? super Object, ? extends Direction>) directionBlockCapability,
+                BDBlockEntities.NET_PATHWAY_BLOCK_ENTITY.get(),
+                (be, side) -> {
+                    DimensionsNet net = be.getNet(); // getNet已经在基类中完成缓存处理
+                    if (net != null && handler != null)
+                    {
+                        if (handler.isContextual())
+                            return handler.apply(net.getUnifiedStorage(), new CapCtx(be.level, be.getBlockPos(), be));
+                        else
+                            return handler.apply(net.getUnifiedStorage(), null);
+                    }
+                    return null;
                 }
         );
     }

--- a/src/main/java/com/wintercogs/beyonddimensions/integration/module/botania/BDBotaniaPlugin.java
+++ b/src/main/java/com/wintercogs/beyonddimensions/integration/module/botania/BDBotaniaPlugin.java
@@ -7,8 +7,6 @@ import com.wintercogs.beyonddimensions.common.menu.widget.slot.ItemCapInteractio
 import com.wintercogs.beyonddimensions.integration.module.botania.storage.ManaStackTypedHandler;
 import com.wintercogs.beyonddimensions.integration.module.botania.storage.ManaUnifiedStorageHandler;
 import net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent;
-import vazkii.botania.api.BotaniaForgeCapabilities;
-import vazkii.botania.common.item.BotaniaItems;
 
 /**
  * 为网络通道和网络接口注册火花附着
@@ -17,13 +15,13 @@ public class BDBotaniaPlugin
 {
     public static void registerItemCapBlackList()
     {
-        ItemCapInteractionBlackList.addToBlackList(BotaniaItems.manaMirror);
+        ItemCapInteractionBlackList.addToBlackList(BotaniaCompat.manaMirror());
     }
 
     public static void registerCapability(RegisterCapabilitiesEvent event)
     {
         event.registerBlockEntity(
-                BotaniaForgeCapabilities.SPARK_ATTACHABLE,
+                BotaniaCompat.sparkAttachable(),
                 BDBlockEntities.NET_PATHWAY_BLOCK_ENTITY.get(),
                 (be, side) -> {
                     DimensionsNet net = be.getNet();
@@ -36,7 +34,7 @@ public class BDBotaniaPlugin
         );
 
         event.registerBlockEntity(
-                BotaniaForgeCapabilities.SPARK_ATTACHABLE,
+                BotaniaCompat.sparkAttachable(),
                 BDBlockEntities.NET_INTERFACE_BLOCK_ENTITY.get(),
                 (be, side) -> {
                     return new ManaStackTypedHandler(be.getStackHandler(), new CapCtx(be.getLevel(), be.getBlockPos(), be));

--- a/src/main/java/com/wintercogs/beyonddimensions/integration/module/botania/BotaniaCompat.java
+++ b/src/main/java/com/wintercogs/beyonddimensions/integration/module/botania/BotaniaCompat.java
@@ -1,0 +1,305 @@
+package com.wintercogs.beyonddimensions.integration.module.botania;
+
+import net.minecraft.core.Direction;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.Block;
+import net.neoforged.neoforge.capabilities.BlockCapability;
+import net.neoforged.neoforge.capabilities.ItemCapability;
+import vazkii.botania.api.block.WandHUD;
+import vazkii.botania.api.block.Wandable;
+import vazkii.botania.api.mana.ManaItem;
+import vazkii.botania.api.mana.ManaReceiver;
+import vazkii.botania.api.mana.spark.SparkAttachable;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+/**
+ * Keeps Botania snapshot API drift out of the integration code.
+ */
+public final class BotaniaCompat
+{
+    private static final String API = "vazkii.botania.api.capability.";
+    private static final String FORGE_CAPS = "vazkii.botania.api.BotaniaForgeCapabilities";
+    private static final String FORGE_CLIENT_CAPS = "vazkii.botania.api.BotaniaForgeClientCapabilities";
+    private static final String XPLAT = "vazkii.botania.xplat.XplatAbstractions";
+    private static final String BOTANIA_ITEMS = "vazkii.botania.common.item.BotaniaItems";
+    private static final String BOTANIA_BLOCKS = "vazkii.botania.common.block.BotaniaBlocks";
+    private static final String ITEM_SOURCE = "vazkii.botania.api.internal.ItemSource";
+    private static final String ITEM_SOURCES = "vazkii.botania.common.internal_caps.ItemSources";
+    private static final String MANA_INFUSION_SPAWNED_TAG = "beyonddimensions:mana_infusion_spawned";
+
+    private static final ResourceLocation MANA_MIRROR = ResourceLocation.fromNamespaceAndPath("botania", "mana_mirror");
+    private static final ResourceLocation MANA_TABLET = ResourceLocation.fromNamespaceAndPath("botania", "mana_tablet");
+    private static final ResourceLocation MANA_VOID = ResourceLocation.fromNamespaceAndPath("botania", "mana_void");
+    private static final ResourceLocation LIVINGROCK = ResourceLocation.fromNamespaceAndPath("botania", "livingrock");
+
+    private BotaniaCompat() {}
+
+    @SuppressWarnings("unchecked")
+    public static BlockCapability<ManaReceiver, Direction> manaReceiver()
+    {
+        return (BlockCapability<ManaReceiver, Direction>) resolveBlockCapability(
+                "vazkii.botania.api.mana.ManaReceiver", "LOOKUP", FORGE_CAPS, "MANA_RECEIVER");
+    }
+
+    @SuppressWarnings("unchecked")
+    public static ItemCapability<ManaItem, Void> manaItem()
+    {
+        return (ItemCapability<ManaItem, Void>) resolveItemCapability(
+                "vazkii.botania.api.mana.ManaItem", "LOOKUP", FORGE_CAPS, "MANA_ITEM");
+    }
+
+    @SuppressWarnings("unchecked")
+    public static BlockCapability<SparkAttachable, Void> sparkAttachable()
+    {
+        return (BlockCapability<SparkAttachable, Void>) resolveBlockCapability(
+                "vazkii.botania.api.mana.spark.SparkAttachable", "LOOKUP", FORGE_CAPS, "SPARK_ATTACHABLE");
+    }
+
+    @SuppressWarnings("unchecked")
+    public static BlockCapability<Wandable, Direction> wandable()
+    {
+        return (BlockCapability<Wandable, Direction>) resolveBlockCapability(
+                "vazkii.botania.api.block.Wandable", "LOOKUP", FORGE_CAPS, "WANDABLE");
+    }
+
+    @SuppressWarnings("unchecked")
+    public static BlockCapability<WandHUD, Void> blockWandHud()
+    {
+        return (BlockCapability<WandHUD, Void>) resolveBlockCapability(
+                "vazkii.botania.api.block.WandHUD", "BLOCK_LOOKUP", FORGE_CLIENT_CAPS, "BLOCK_WAND_HUD");
+    }
+
+    public static Item manaMirror()
+    {
+        return item(MANA_MIRROR, "manaMirror", "MANA_MIRROR");
+    }
+
+    public static Item manaTablet()
+    {
+        return item(MANA_TABLET, "manaTablet", "MANA_TABLET");
+    }
+
+    public static Block manaVoid()
+    {
+        return block(MANA_VOID, "manaVoid", "MANA_VOID");
+    }
+
+    public static Block livingrock()
+    {
+        return block(LIVINGROCK, "livingrock", "LIVINGROCK");
+    }
+
+    public static ManaItem findManaItem(ItemStack stack)
+    {
+        Object xplat = xplat();
+        try
+        {
+            Method findManaItem = Class.forName(XPLAT).getMethod("findManaItem", ItemStack.class);
+            return (ManaItem) findManaItem.invoke(xplat, stack);
+        }
+        catch (ReflectiveOperationException | LinkageError ignored)
+        {
+            // Botania 454 removed findManaItem in favor of findItemApi(ManaItem.LOOKUP, stack).
+        }
+
+        try
+        {
+            Object lookup = field("vazkii.botania.api.mana.ManaItem", "LOOKUP");
+            Method findItemApi = Class.forName(XPLAT).getMethod("findItemApi", Class.forName(API + "ItemApiNoContext"), ItemStack.class);
+            return (ManaItem) findItemApi.invoke(xplat, lookup, stack);
+        }
+        catch (ReflectiveOperationException | LinkageError e)
+        {
+            throw new IllegalStateException("Beyond Dimensions: unable to resolve Botania mana item API", e);
+        }
+    }
+
+    public static boolean isManaInfusionSpawned(ItemEntity item)
+    {
+        if (item.getPersistentData().getBoolean(MANA_INFUSION_SPAWNED_TAG))
+        {
+            return true;
+        }
+
+        try
+        {
+            Object source = itemSource(item);
+            return source == field(ITEM_SOURCES, "MANA_INFUSION");
+        }
+        catch (ReflectiveOperationException | LinkageError ignored)
+        {
+            // Botania 454+ uses ItemSource attachments; older versions used item flags.
+        }
+
+        try
+        {
+            Object flags = itemFlagsComponent(item);
+            return flags.getClass().getField("manaInfusionSpawned").getBoolean(flags);
+        }
+        catch (ReflectiveOperationException | LinkageError ignored)
+        {
+            return false;
+        }
+    }
+
+    public static void setManaInfusionSpawned(ItemEntity item)
+    {
+        item.getPersistentData().putBoolean(MANA_INFUSION_SPAWNED_TAG, true);
+
+        try
+        {
+            setItemSource(item, field(ITEM_SOURCES, "MANA_INFUSION"));
+        }
+        catch (ReflectiveOperationException | LinkageError ignored)
+        {
+            // Older Botania versions do not expose the ItemSource attachment.
+        }
+
+        try
+        {
+            Object flags = itemFlagsComponent(item);
+            flags.getClass().getField("manaInfusionSpawned").setBoolean(flags, true);
+        }
+        catch (ReflectiveOperationException | LinkageError ignored)
+        {
+            // Newer Botania versions do not expose this legacy component.
+        }
+    }
+
+    private static BlockCapability<?, ?> resolveBlockCapability(String newHolder, String newField, String oldHolder, String oldField)
+    {
+        try
+        {
+            Object lookup = field(newHolder, newField);
+            Class<?> caps = Class.forName(FORGE_CAPS);
+            Class<?> withCtx = Class.forName(API + "BlockApiWithContext");
+            Class<?> param = withCtx.isInstance(lookup) ? withCtx : Class.forName(API + "BlockApiNoContext");
+            Method getById = caps.getMethod("getBlockApiLookupById", param);
+            BlockCapability<?, ?> capability = (BlockCapability<?, ?>) getById.invoke(null, lookup);
+            if (capability != null)
+            {
+                return capability;
+            }
+        }
+        catch (ReflectiveOperationException | LinkageError ignored)
+        {
+            // Fall back to the pre-454 fields.
+        }
+
+        try
+        {
+            return (BlockCapability<?, ?>) field(oldHolder, oldField);
+        }
+        catch (ReflectiveOperationException | LinkageError e)
+        {
+            throw new IllegalStateException("Beyond Dimensions: unable to resolve Botania block capability " + newHolder + "#" + newField + " / " + oldHolder + "#" + oldField, e);
+        }
+    }
+
+    private static ItemCapability<?, ?> resolveItemCapability(String newHolder, String newField, String oldHolder, String oldField)
+    {
+        try
+        {
+            Object lookup = field(newHolder, newField);
+            Class<?> caps = Class.forName(FORGE_CAPS);
+            Class<?> withCtx = Class.forName(API + "ItemApiWithContext");
+            Class<?> param = withCtx.isInstance(lookup) ? withCtx : Class.forName(API + "ItemApiNoContext");
+            Method getById = caps.getMethod("getItemApiLookupById", param);
+            ItemCapability<?, ?> capability = (ItemCapability<?, ?>) getById.invoke(null, lookup);
+            if (capability != null)
+            {
+                return capability;
+            }
+        }
+        catch (ReflectiveOperationException | LinkageError ignored)
+        {
+            // Fall back to the pre-454 fields.
+        }
+
+        try
+        {
+            return (ItemCapability<?, ?>) field(oldHolder, oldField);
+        }
+        catch (ReflectiveOperationException | LinkageError e)
+        {
+            throw new IllegalStateException("Beyond Dimensions: unable to resolve Botania item capability " + newHolder + "#" + newField + " / " + oldHolder + "#" + oldField, e);
+        }
+    }
+
+    private static Item item(ResourceLocation id, String... fallbackFields)
+    {
+        return BuiltInRegistries.ITEM.getOptional(id)
+                .orElseGet(() -> (Item) fallback(BOTANIA_ITEMS, id, fallbackFields));
+    }
+
+    private static Block block(ResourceLocation id, String... fallbackFields)
+    {
+        return BuiltInRegistries.BLOCK.getOptional(id)
+                .orElseGet(() -> (Block) fallback(BOTANIA_BLOCKS, id, fallbackFields));
+    }
+
+    private static Object fallback(String className, ResourceLocation id, String... fieldNames)
+    {
+        for (String fieldName : fieldNames)
+        {
+            try
+            {
+                return field(className, fieldName);
+            }
+            catch (ReflectiveOperationException | LinkageError ignored)
+            {
+                // Try the next spelling.
+            }
+        }
+        throw new IllegalStateException("Beyond Dimensions: unable to resolve Botania registry entry " + id);
+    }
+
+    private static Object xplat()
+    {
+        try
+        {
+            return field(XPLAT, "INSTANCE");
+        }
+        catch (ReflectiveOperationException | LinkageError ignored)
+        {
+            try
+            {
+                return Class.forName(XPLAT).getMethod("instance").invoke(null);
+            }
+            catch (ReflectiveOperationException | LinkageError e)
+            {
+                throw new IllegalStateException("Beyond Dimensions: unable to access Botania xplat bridge", e);
+            }
+        }
+    }
+
+    private static Object itemFlagsComponent(ItemEntity item) throws ReflectiveOperationException
+    {
+        return Class.forName(XPLAT).getMethod("itemFlagsComponent", ItemEntity.class).invoke(xplat(), item);
+    }
+
+    private static Object itemSource(ItemEntity item) throws ReflectiveOperationException
+    {
+        Object holder = field(ITEM_SOURCE, "HOLDER");
+        return holder.getClass().getMethod("getOrDefault", Entity.class, Object.class).invoke(holder, item, null);
+    }
+
+    private static void setItemSource(ItemEntity item, Object source) throws ReflectiveOperationException
+    {
+        Object holder = field(ITEM_SOURCE, "HOLDER");
+        holder.getClass().getMethod("setFor", Entity.class, Object.class).invoke(holder, item, source);
+    }
+
+    private static Object field(String className, String fieldName) throws ReflectiveOperationException
+    {
+        Field f = Class.forName(className).getField(fieldName);
+        return f.get(null);
+    }
+}

--- a/src/main/java/com/wintercogs/beyonddimensions/integration/module/botania/BotaniaModule.java
+++ b/src/main/java/com/wintercogs/beyonddimensions/integration/module/botania/BotaniaModule.java
@@ -3,6 +3,8 @@ package com.wintercogs.beyonddimensions.integration.module.botania;
 import com.wintercogs.beyonddimensions.api.capability.helper.CapabilityHelper;
 import com.wintercogs.beyonddimensions.api.capability.helper.wrapper.StackHandlerWrapperHelper;
 import com.wintercogs.beyonddimensions.api.storage.key.StackKeyRegistry;
+import com.wintercogs.beyonddimensions.common.block.entity.NetInterfaceBlockEntity;
+import com.wintercogs.beyonddimensions.common.block.entity.NetPathwayBlockEntity;
 import com.wintercogs.beyonddimensions.integration.BDIntegrationModule;
 import com.wintercogs.beyonddimensions.integration.IIntegrationModule;
 import com.wintercogs.beyonddimensions.integration.OtherModIds;
@@ -26,10 +28,14 @@ import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.level.storage.loot.parameters.LootContextParamSets;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
+import net.neoforged.neoforge.capabilities.BlockCapability;
+import net.neoforged.neoforge.capabilities.ItemCapability;
+import net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent;
 import net.neoforged.neoforge.common.data.ExistingFileHelper;
 import net.neoforged.neoforge.data.event.GatherDataEvent;
 import org.jetbrains.annotations.NotNull;
-import vazkii.botania.api.BotaniaForgeCapabilities;
+import vazkii.botania.api.mana.ManaItem;
+import vazkii.botania.api.mana.ManaReceiver;
 
 import java.util.Collections;
 import java.util.List;
@@ -52,6 +58,7 @@ public class BotaniaModule implements IIntegrationModule
 
         modBus.addListener(ManaPoolPathwayBlockEntity::registerCapability);
         modBus.addListener(BDBotaniaPlugin::registerCapability);
+        modBus.addListener(this::registerNetCapabilities);
         gameBus.addListener(BotaniaModuleDataPackSyncListener::onDataPackSync);
     }
 
@@ -59,14 +66,22 @@ public class BotaniaModule implements IIntegrationModule
     public void onCommonSetup(FMLCommonSetupEvent event)
     {
         StackKeyRegistry.registerType(ManaStackKey.INSTANCE);
-        CapabilityHelper.BlockCapabilityMap.put(ManaStackKey.ID, BotaniaForgeCapabilities.MANA_RECEIVER);
-        CapabilityHelper.ItemCapabilityMap.put(ManaStackKey.ID, BotaniaForgeCapabilities.MANA_ITEM);
         CapabilityHelper.registerUSHandler(ManaStackKey.INSTANCE, ManaUnifiedStorageHandler::new);
         CapabilityHelper.registerStackTypedHandler(ManaStackKey.INSTANCE, ManaStackTypedHandler::new);
         StackHandlerWrapperHelper.stackWrappers.put(ManaStackKey.ID, ManaHandlerWrapper::new);
 
         // 能力交互黑名单（魔力手镜）
         BDBotaniaPlugin.registerItemCapBlackList();
+    }
+
+    private void registerNetCapabilities(RegisterCapabilitiesEvent event)
+    {
+        BlockCapability<ManaReceiver, net.minecraft.core.Direction> manaReceiver = BotaniaCompat.manaReceiver();
+        ItemCapability<ManaItem, Void> manaItem = BotaniaCompat.manaItem();
+        CapabilityHelper.BlockCapabilityMap.put(ManaStackKey.ID, manaReceiver);
+        CapabilityHelper.ItemCapabilityMap.put(ManaStackKey.ID, manaItem);
+        NetInterfaceBlockEntity.registerCapability(event, ManaStackKey.ID, manaReceiver);
+        NetPathwayBlockEntity.registerCapability(event, ManaStackKey.ID, manaReceiver);
     }
 
     @Override

--- a/src/main/java/com/wintercogs/beyonddimensions/integration/module/botania/block/entity/ManaPoolPathwayBlockEntity.java
+++ b/src/main/java/com/wintercogs/beyonddimensions/integration/module/botania/block/entity/ManaPoolPathwayBlockEntity.java
@@ -4,6 +4,7 @@ import com.mojang.blaze3d.platform.Window;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.wintercogs.beyonddimensions.api.util.CapCtx;
 import com.wintercogs.beyonddimensions.common.block.entity.NetedBlockEntity;
+import com.wintercogs.beyonddimensions.integration.module.botania.BotaniaCompat;
 import com.wintercogs.beyonddimensions.integration.module.botania.init.BotaniaModuleBlockEntities;
 import com.wintercogs.beyonddimensions.integration.module.botania.storage.ManaUnifiedStorageHandler;
 import com.wintercogs.beyonddimensions.util.BDMath;
@@ -30,6 +31,7 @@ import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.api.distmarker.OnlyIn;
+import net.neoforged.fml.loading.FMLEnvironment;
 import net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.jetbrains.annotations.NotNull;
@@ -37,12 +39,9 @@ import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.UnknownNullability;
 import org.lwjgl.opengl.GL11;
 import vazkii.botania.api.BotaniaAPIClient;
-import vazkii.botania.api.BotaniaForgeCapabilities;
-import vazkii.botania.api.BotaniaForgeClientCapabilities;
 import vazkii.botania.api.block.WandHUD;
 import vazkii.botania.api.block.Wandable;
 import vazkii.botania.api.internal.ManaBurst;
-import vazkii.botania.api.internal.VanillaPacketDispatcher;
 import vazkii.botania.api.item.ManaDissolvable;
 import vazkii.botania.api.mana.KeyLocked;
 import vazkii.botania.api.mana.ManaCollector;
@@ -53,18 +52,14 @@ import vazkii.botania.client.core.helper.RenderHelper;
 import vazkii.botania.client.fx.SparkleParticleData;
 import vazkii.botania.client.fx.WispParticleData;
 import vazkii.botania.client.gui.HUDHandler;
-import vazkii.botania.common.block.BotaniaBlocks;
 import vazkii.botania.common.block.block_entity.mana.BellowsBlockEntity;
 import vazkii.botania.common.block.block_entity.mana.ManaPoolBlockEntity;
-import vazkii.botania.common.block.block_entity.mana.ThrottledPacket;
 import vazkii.botania.common.crafting.BotaniaRecipeTypes;
 import vazkii.botania.common.crafting.StateIngredients;
 import vazkii.botania.common.handler.BotaniaSounds;
 import vazkii.botania.common.helper.EntityHelper;
-import vazkii.botania.common.item.BotaniaItems;
 import vazkii.botania.common.item.ManaTabletItem;
 import vazkii.botania.xplat.BotaniaConfig;
-import vazkii.botania.xplat.XplatAbstractions;
 
 import java.util.List;
 
@@ -72,7 +67,7 @@ import java.util.List;
  * 既可以为功能花提供魔力，也可以从产能花以及魔力发射器接收魔力，并能并入火花网络的魔力池
  */
 public class ManaPoolPathwayBlockEntity extends NetedBlockEntity
-        implements ManaCollector, ManaPool, SparkAttachable, Wandable, KeyLocked, ThrottledPacket
+        implements ManaCollector, ManaPool, SparkAttachable, Wandable, KeyLocked
 {
 
     // Botania 常量/事件
@@ -140,25 +135,28 @@ public class ManaPoolPathwayBlockEntity extends NetedBlockEntity
     public static void registerCapability(RegisterCapabilitiesEvent event)
     {
         event.registerBlockEntity(
-                BotaniaForgeCapabilities.MANA_RECEIVER,
+                BotaniaCompat.manaReceiver(),
                 BotaniaModuleBlockEntities.MANA_POOL_PATHWAY_BLOCK_ENTITY.get(),
                 (be, side) -> be instanceof ManaPoolPathwayBlockEntity pool ? pool : null
         );
 
         event.registerBlockEntity(
-                BotaniaForgeCapabilities.SPARK_ATTACHABLE,
+                BotaniaCompat.sparkAttachable(),
                 BotaniaModuleBlockEntities.MANA_POOL_PATHWAY_BLOCK_ENTITY.get(),
                 (be, side) -> be instanceof ManaPoolPathwayBlockEntity pool ? pool : null
         );
 
-        event.registerBlockEntity(
-                BotaniaForgeClientCapabilities.BLOCK_WAND_HUD,
-                BotaniaModuleBlockEntities.MANA_POOL_PATHWAY_BLOCK_ENTITY.get(),
-                (be, side) -> be instanceof ManaPoolPathwayBlockEntity pool ? new WandHud(pool) : null
-        );
+        if (FMLEnvironment.dist == Dist.CLIENT)
+        {
+            event.registerBlockEntity(
+                    BotaniaCompat.blockWandHud(),
+                    BotaniaModuleBlockEntities.MANA_POOL_PATHWAY_BLOCK_ENTITY.get(),
+                    (be, side) -> be instanceof ManaPoolPathwayBlockEntity pool ? new WandHud(pool) : null
+            );
+        }
 
         event.registerBlockEntity(
-                BotaniaForgeCapabilities.WANDABLE,
+                BotaniaCompat.wandable(),
                 BotaniaModuleBlockEntities.MANA_POOL_PATHWAY_BLOCK_ENTITY.get(),
                 (be, side) -> be instanceof ManaPoolPathwayBlockEntity pool ? pool : null
         );
@@ -196,8 +194,7 @@ public class ManaPoolPathwayBlockEntity extends NetedBlockEntity
         // 10 tick节流发包
         if (be.sendPacket && be.ticks % 10 == 0)
         {
-            VanillaPacketDispatcher.dispatchTEToNearbyPlayers(be);
-            be.sendPacket = false;
+            be.syncNow(level, pos, state);
         }
 
         // 扫描池内物品
@@ -207,7 +204,7 @@ public class ManaPoolPathwayBlockEntity extends NetedBlockEntity
             if (!item.isAlive()) continue;
 
             ItemStack stack = item.getItem();
-            var mana = XplatAbstractions.INSTANCE.findManaItem(stack);
+            var mana = BotaniaCompat.findManaItem(stack);
             if (stack.isEmpty() || mana == null) continue;
 
             boolean isOutputting = be.isOutputtingPower();
@@ -253,7 +250,7 @@ public class ManaPoolPathwayBlockEntity extends NetedBlockEntity
                     int space = BDMath.clampLongToInt(be.getActualMaxMana() - be.getActualCurrentMana());
                     int manaVal = Math.min(transfRate, Math.min(space, mana.getMana()));
 
-                    if (manaVal == 0 && level.getBlockState(pos.below()).is(BotaniaBlocks.manaVoid))
+                    if (manaVal == 0 && level.getBlockState(pos.below()).is(BotaniaCompat.manaVoid()))
                     {
                         manaVal = Math.min(transfRate, mana.getMana());
                     }
@@ -292,7 +289,7 @@ public class ManaPoolPathwayBlockEntity extends NetedBlockEntity
             be.ticksDoingTransfer = 0;
             if (wasDoingTransfer)
             {
-                VanillaPacketDispatcher.dispatchTEToNearbyPlayers(be);
+                be.syncNow(level, pos, state);
             }
         }
 
@@ -314,7 +311,7 @@ public class ManaPoolPathwayBlockEntity extends NetedBlockEntity
             dissolvable.onDissolveTick(this, item);
         }
 
-        if (XplatAbstractions.INSTANCE.itemFlagsComponent(item).manaInfusionSpawned)
+        if (BotaniaCompat.isManaInfusionSpawned(item))
         {
             return false;
         }
@@ -333,7 +330,7 @@ public class ManaPoolPathwayBlockEntity extends NetedBlockEntity
 
                 ItemEntity outputItem = new ItemEntity(level,
                         worldPosition.getX() + 0.5, worldPosition.getY() + 1.5, worldPosition.getZ() + 0.5, output);
-                XplatAbstractions.INSTANCE.itemFlagsComponent(outputItem).manaInfusionSpawned = true;
+                BotaniaCompat.setManaInfusionSpawned(outputItem);
 
                 if (item.getOwner() instanceof Player player)
                 {
@@ -622,7 +619,7 @@ public class ManaPoolPathwayBlockEntity extends NetedBlockEntity
         if (refreshHandler())
         {
             handler.receiveMana(mana);
-            markDispatchable();
+            queueSync();
             setChanged();
         }
     }
@@ -658,8 +655,7 @@ public class ManaPoolPathwayBlockEntity extends NetedBlockEntity
         {
             isOutPutting = !isOutPutting;
             setChanged();
-            markDispatchable();
-            VanillaPacketDispatcher.dispatchTEToNearbyPlayers(this);
+            syncNow(level, worldPosition, getBlockState());
         }
         return true;
     }
@@ -723,10 +719,15 @@ public class ManaPoolPathwayBlockEntity extends NetedBlockEntity
         return best;
     }
 
-    @Override
-    public void markDispatchable()
+    private void queueSync()
     {
         sendPacket = true;
+    }
+
+    private void syncNow(Level level, BlockPos pos, BlockState state)
+    {
+        level.sendBlockUpdated(pos, state, state, 3);
+        sendPacket = false;
     }
 
     @Override
@@ -774,7 +775,7 @@ public class ManaPoolPathwayBlockEntity extends NetedBlockEntity
             RenderHelper.drawTexturedModalRect(gui, HUDHandler.manaBar, centerX - 11, centerY + 30, arrowU, arrowV, 22, 15);
             RenderSystem.setShaderColor(1F, 1F, 1F, 1F);
 
-            ItemStack tablet = new ItemStack(BotaniaItems.manaTablet);
+            ItemStack tablet = new ItemStack(BotaniaCompat.manaTablet());
             ManaTabletItem.setStackCreative(tablet);
 
             gui.renderItem(tablet, centerX - 31, centerY + 30);

--- a/src/main/java/com/wintercogs/beyonddimensions/integration/module/botania/datagen/BotaniaModuleRecipeProvider.java
+++ b/src/main/java/com/wintercogs/beyonddimensions/integration/module/botania/datagen/BotaniaModuleRecipeProvider.java
@@ -2,6 +2,7 @@ package com.wintercogs.beyonddimensions.integration.module.botania.datagen;
 
 import com.wintercogs.beyonddimensions.common.init.BDItems;
 import com.wintercogs.beyonddimensions.datagen.util.BDRecipeProvider;
+import com.wintercogs.beyonddimensions.integration.module.botania.BotaniaCompat;
 import com.wintercogs.beyonddimensions.integration.OtherModIds;
 import com.wintercogs.beyonddimensions.integration.module.botania.init.BotaniaModuleBlocks;
 import net.minecraft.core.HolderLookup;
@@ -10,7 +11,6 @@ import net.minecraft.data.recipes.RecipeCategory;
 import net.minecraft.data.recipes.RecipeOutput;
 import net.minecraft.data.recipes.ShapedRecipeBuilder;
 import org.jetbrains.annotations.NotNull;
-import vazkii.botania.common.block.BotaniaBlocks;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -38,7 +38,7 @@ public class BotaniaModuleRecipeProvider extends BDRecipeProvider
         ShapedRecipeBuilder.shaped(RecipeCategory.MISC, BotaniaModuleBlocks.MANA_POOL_PATHWAY.get())
                 .pattern("ABA")
                 .pattern("AAA")
-                .define('A', BotaniaBlocks.livingrock)
+                .define('A', BotaniaCompat.livingrock())
                 .define('B', BDItems.SPACE_TIME_STABLE_FRAME.get())
                 .unlockedBy("unlock_mana_pool_pathway", has(BDItems.SPACE_TIME_STABLE_FRAME.get()))
                 .save(compatOutput);

--- a/src/main/templates/META-INF/neoforge.mods.toml
+++ b/src/main/templates/META-INF/neoforge.mods.toml
@@ -86,6 +86,13 @@ config="${mod_id}.mixins.json"
     ordering="NONE"
     side="BOTH"
 
+[[dependencies.${mod_id}]]
+    modId="botania"
+    type="optional"
+    versionRange="[0,)"
+    ordering="AFTER"
+    side="BOTH"
+
 # Features are specific properties of the game environment, that you may want to declare you require. This example declares
 # that your mod requires GL version 3.2 or higher. Other features will be added. They are side aware so declaring this won't
 # stop your mod loading on the server for example.


### PR DESCRIPTION
## 概述

修复 Botania 451 与 454 之间的 API 漂移导致的兼容性问题，避免在 Botania 454 snapshot 环境中触发 capability、内部包名和客户端专用能力变更相关的运行期异常。

Fixes #51.

## 改动

新增 `BotaniaCompat`，集中处理 Botania 451 与 454 的 API 漂移：**优先走新版 API 或注册名解析**，失败后再**回退旧字段/旧方法**。

其余改动仅把 Botania 集成模块内对不稳定 API 的直接引用替换为该兼容层调用，并调整维度魔力池通道的同步与客户端 capability 注册方式。

| 旧路径 / 旧行为 | 新兼容路径 |
|---|---|
| `BotaniaForgeCapabilities.MANA_RECEIVER` | `ManaReceiver.LOOKUP` → `getBlockApiLookupById(...)`，失败回退旧字段 |
| `BotaniaForgeCapabilities.MANA_ITEM` | `ManaItem.LOOKUP` → `getItemApiLookupById(...)`，失败回退旧字段 |
| `BotaniaForgeCapabilities.SPARK_ATTACHABLE` | `SparkAttachable.LOOKUP` → `getBlockApiLookupById(...)`，失败回退旧字段 |
| `BotaniaForgeCapabilities.WANDABLE` | `Wandable.LOOKUP` → `getBlockApiLookupById(...)`，失败回退旧字段 |
| `BotaniaForgeClientCapabilities.BLOCK_WAND_HUD` | `WandHUD.BLOCK_LOOKUP` → `getBlockApiLookupById(...)`，且仅客户端注册 |
| `BotaniaItems.manaMirror` / `manaTablet` | 优先按注册名 `botania:mana_mirror` / `botania:mana_tablet` 解析，失败回退旧字段 |
| `BotaniaBlocks.manaVoid` / `livingrock` | 优先按注册名 `botania:mana_void` / `botania:livingrock` 解析，失败回退旧字段 |
| `XplatAbstractions.findManaItem(stack)` | 优先调用 `findItemApi(ManaItem.LOOKUP, stack)`，失败回退旧方法 |
| Botania 旧 item flags 标记魔力灌注产物 | 同时写入本模组持久标记、旧 item flags 与 454 `ItemSources.MANA_INFUSION` |
| 直接依赖 `VanillaPacketDispatcher` / `ThrottledPacket` | 移除内部实现依赖，复用本模组已有同步流程 |

此外，`ItemSources.MANA_INFUSION` 的判断使用引用身份比较，而不是 `equals`。Botania 454 的 `ItemSource` 是 record，多个来源都可能是 `new ItemSource(true)`；使用 `equals` 会把花药台、符文祭坛等其他来源误判为魔力灌注产物。

## 兼容性

- **Botania 454-SNAPSHOT**：走 `LOOKUP`、注册名解析、`findItemApi(...)` 与 `ItemSource` 标记路径，不再依赖已删除/迁移的字段和内部类。
- **Botania 451 及旧 API 环境**：新版路径不可用时回退旧字段、旧方法和旧 item flags，保持原行为。
- **Dedicated server**：`WandHUD` capability 只在客户端 dist 注册，避免服务端解析客户端专用 capability。

即同一份 jar 可在 Botania 451 与 454 snapshot 环境中加载，并保持维度魔力池通道的既有行为。

## 验证

- 在1.21.1 NeoForge 2.1.1.233中搭配botania-neoforge-1.21.1-454-20260618.183251-45.jar测试版未发现问题(GPT写的,我review了下应该没什么问题)